### PR TITLE
Miscellanous cleanups

### DIFF
--- a/Tests/Fluent.Tests/Batch/BatchTests.cs
+++ b/Tests/Fluent.Tests/Batch/BatchTests.cs
@@ -64,7 +64,6 @@ namespace Fluent.Tests
                             .Apply();
 
                     Assert.NotNull(batchAccount.AutoStorage.StorageAccountId);
-                    Assert.NotNull(batchAccount.AutoStorage.LastKeySync);
                     var lastSync = batchAccount.AutoStorage.LastKeySync;
 
                     batchAccount.SynchronizeAutoStorageKeys();

--- a/Tests/Fluent.Tests/Compute/VirtualMachineAvailabilityZoneOperationsTests.cs
+++ b/Tests/Fluent.Tests/Compute/VirtualMachineAvailabilityZoneOperationsTests.cs
@@ -287,7 +287,6 @@ namespace Fluent.Tests.Compute.VirtuaMachine
                         .Create();
 
                     string pipDnsLabel = TestUtilities.GenerateName("pip");
-                    string vmName = "javavm";
 
                     var subnets = network.Subnets.Values.GetEnumerator();
                     // Define first regional virtual machine
@@ -377,7 +376,7 @@ namespace Fluent.Tests.Compute.VirtuaMachine
                     ILoadBalancerFrontend frontend = lb.Frontends.Values.First();
                     Assert.True(frontend.IsPublic);
                     ILoadBalancerPublicFrontend publicFrontend = (ILoadBalancerPublicFrontend)frontend;
-                    Assert.True(publicIPAddress.Id.Equals(publicFrontend.PublicIPAddressId, StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal(publicIPAddress.Id, publicFrontend.PublicIPAddressId, ignoreCase: true);
 
                     // Verify backends
                     Assert.Equal(1, lb.Backends.Count);
@@ -391,7 +390,7 @@ namespace Fluent.Tests.Compute.VirtuaMachine
                     Assert.True(lb.LoadBalancingRules.ContainsKey("rule-1"));
                     ILoadBalancingRule rule = lb.LoadBalancingRules["rule-1"];
                     Assert.NotNull(rule.Backend);
-                    Assert.True(rule.Probe.Name.Equals("tcpProbe-1", StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal("tcpProbe-1", rule.Probe.Name, ignoreCase: true);
 
                     // Note that above configuration is not possible for BASIC LB, BASIC LB has following limitation
                     // It supports VMs only in a single availability Set in a backend pool, though multiple backend pool
@@ -440,7 +439,6 @@ namespace Fluent.Tests.Compute.VirtuaMachine
                         .Create();
 
                     string pipDnsLabel = TestUtilities.GenerateName("pip");
-                    string vmName = "javavm";
 
                     var subnets = network.Subnets.Values.GetEnumerator();
                     // Define first regional virtual machine
@@ -532,7 +530,7 @@ namespace Fluent.Tests.Compute.VirtuaMachine
                     ILoadBalancerFrontend frontend = lb.Frontends.Values.First();
                     Assert.True(frontend.IsPublic);
                     ILoadBalancerPublicFrontend publicFrontend = (ILoadBalancerPublicFrontend)frontend;
-                    Assert.True(publicIPAddress.Id.Equals(publicFrontend.PublicIPAddressId, StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal(publicIPAddress.Id, publicFrontend.PublicIPAddressId, ignoreCase: true);
 
                     // Verify backends
                     Assert.Equal(1, lb.Backends.Count);
@@ -546,7 +544,7 @@ namespace Fluent.Tests.Compute.VirtuaMachine
                     Assert.True(lb.LoadBalancingRules.ContainsKey("rule-1"));
                     ILoadBalancingRule rule = lb.LoadBalancingRules["rule-1"];
                     Assert.NotNull(rule.Backend);
-                    Assert.True(rule.Probe.Name.Equals("tcpProbe-1", StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal("tcpProbe-1", rule.Probe.Name, ignoreCase: true);
                     // Zone resilient LB does not care VMs are zoned or regional, in the above cases VMs are zoned.
                     //
 

--- a/Tests/Fluent.Tests/Compute/VirtualMachineExtensionImageTests.cs
+++ b/Tests/Fluent.Tests/Compute/VirtualMachineExtensionImageTests.cs
@@ -27,7 +27,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                 // Lazy listing
                 var firstTwenty = extensionImages.Take(maxListing).ToList();
                 Assert.Equal(firstTwenty.Count(), maxListing);
-                Assert.False(firstTwenty.Any(image => image == null));
+                Assert.DoesNotContain(null, firstTwenty);
                 // Make sure all the elements are unique and we did not return any duplicates
                 Assert.Equal(firstTwenty.Distinct().Count(), maxListing);
             }

--- a/Tests/Fluent.Tests/Compute/VirtualMachineExtensionTests.cs
+++ b/Tests/Fluent.Tests/Compute/VirtualMachineExtensionTests.cs
@@ -115,9 +115,9 @@ namespace Fluent.Tests.Compute.VirtualMachine
                 IVirtualMachineExtension customScriptExtension;
                 Assert.True(vm.ListExtensions().TryGetValue("CustomScriptForLinux", out customScriptExtension));
                 Assert.NotNull(customScriptExtension);
-                Assert.Equal(customScriptExtension.PublisherName, "Microsoft.OSTCExtensions");
-                Assert.Equal(customScriptExtension.TypeName, "CustomScriptForLinux");
-                Assert.Equal(customScriptExtension.AutoUpgradeMinorVersionEnabled, true);
+                Assert.Equal("Microsoft.OSTCExtensions", customScriptExtension.PublisherName);
+                Assert.Equal("CustomScriptForLinux", customScriptExtension.TypeName);
+                Assert.True(customScriptExtension.AutoUpgradeMinorVersionEnabled);
 
                 // Ensure the public settings are accessible, the protected settings won't be returned from the service.
                 //
@@ -128,7 +128,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                 Assert.True(publicSettings.ContainsKey("commandToExecute"));
                 string commandToExecute = (string)publicSettings["commandToExecute"];
                 Assert.NotNull(commandToExecute);
-                Assert.True(commandToExecute.Equals(installCommand, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal(commandToExecute, installCommand, true);
 
                 // Remove the custom extension
                 //
@@ -288,9 +288,9 @@ namespace Fluent.Tests.Compute.VirtualMachine
                 IVirtualMachineExtension customScriptExtension;
                 Assert.True(vm.ListExtensions().TryGetValue("CustomScriptForLinux", out customScriptExtension));
                 Assert.NotNull(customScriptExtension);
-                Assert.Equal(customScriptExtension.PublisherName, "Microsoft.OSTCExtensions");
-                Assert.Equal(customScriptExtension.TypeName, "CustomScriptForLinux");
-                Assert.Equal(customScriptExtension.AutoUpgradeMinorVersionEnabled, true);
+                Assert.Equal("Microsoft.OSTCExtensions", customScriptExtension.PublisherName, true);
+                Assert.Equal("CustomScriptForLinux", customScriptExtension.TypeName, true);
+                Assert.True(customScriptExtension.AutoUpgradeMinorVersionEnabled);
 
                 // Special check for C# implementation, seems runtime changed the actual type
                 // of public settings from dictionary to Newtonsoft.Json.Linq.JObject.
@@ -312,7 +312,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                 string fileUrisString = (publicSettings["fileUris"]).ToString();
                 if (HttpMockServer.Mode != HttpRecorderMode.Playback)
                 {
-                    Assert.True(fileUrisString.Contains(uri));
+                    Assert.Contains(uri, fileUrisString);
                 }
 
                 /*** UPDATE THE EXTENSION WITH NEW PUBLIC AND PROTECTED SETTINGS **/
@@ -348,9 +348,9 @@ namespace Fluent.Tests.Compute.VirtualMachine
                 IVirtualMachineExtension customScriptExtension2;
                 Assert.True(vm.ListExtensions().TryGetValue("CustomScriptForLinux", out customScriptExtension2));
                 Assert.NotNull(customScriptExtension2);
-                Assert.Equal(customScriptExtension2.PublisherName, "Microsoft.OSTCExtensions");
-                Assert.Equal(customScriptExtension2.TypeName, "CustomScriptForLinux");
-                Assert.Equal(customScriptExtension2.AutoUpgradeMinorVersionEnabled, true);
+                Assert.Equal("Microsoft.OSTCExtensions", customScriptExtension2.PublisherName, true);
+                Assert.Equal("CustomScriptForLinux", customScriptExtension2.TypeName, true);
+                Assert.True(customScriptExtension2.AutoUpgradeMinorVersionEnabled);
 
                 var publicSettings2 = customScriptExtension2.PublicSettings;
                 Assert.NotNull(publicSettings2);
@@ -360,7 +360,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                 string fileUris2String = (publicSettings2["fileUris"]).ToString();
                 if (HttpMockServer.Mode != HttpRecorderMode.Playback)
                 {
-                    Assert.True(fileUris2String.Contains(uri2));
+                    Assert.Contains(uri2, fileUris2String);
                 }
             }
         }

--- a/Tests/Fluent.Tests/Compute/VirtualMachineManagedDiskOperationsTests.cs
+++ b/Tests/Fluent.Tests/Compute/VirtualMachineManagedDiskOperationsTests.cs
@@ -52,14 +52,14 @@ namespace Fluent.Tests.Compute.VirtualMachine
                     // backing os disk
                     //
                     Assert.NotNull(virtualMachine.OSDiskStorageAccountType);
-                    Assert.Equal(virtualMachine.OSDiskCachingType, CachingTypes.ReadWrite);
+                    Assert.Equal(CachingTypes.ReadWrite, virtualMachine.OSDiskCachingType);
                     Assert.Equal(virtualMachine.Size, VirtualMachineSizeTypes.StandardD5V2);
                     // Validate the implicit managed disk created by CRP to back the os disk
                     //
                     Assert.NotNull(virtualMachine.OSDiskId);
                     var osDisk = computeManager.Disks.GetById(virtualMachine.OSDiskId);
                     Assert.True(osDisk.IsAttachedToVirtualMachine);
-                    Assert.Equal(osDisk.OSType, OperatingSystemTypes.Linux);
+                    Assert.Equal(OperatingSystemTypes.Linux, osDisk.OSType);
                     // Check the auto created public ip
                     //
                     var publicIPId = virtualMachine.GetPrimaryPublicIPAddressId();
@@ -152,7 +152,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                     // There should not be any un-managed data disks
                     //
                     Assert.NotNull(virtualMachine.UnmanagedDataDisks);
-                    Assert.Equal(virtualMachine.UnmanagedDataDisks.Count, 0);
+                    Assert.Equal(0, virtualMachine.UnmanagedDataDisks.Count);
                     // Validate the managed data disks
                     //
                     var dataDisks = virtualMachine.DataDisks;
@@ -161,28 +161,28 @@ namespace Fluent.Tests.Compute.VirtualMachine
                     Assert.True(dataDisks.ContainsKey(1));
                     var dataDiskLun1 = dataDisks[1];
                     Assert.NotNull(dataDiskLun1.Id);
-                    Assert.Equal(dataDiskLun1.CachingType, CachingTypes.ReadOnly);
-                    Assert.Equal(dataDiskLun1.Size, 100);
+                    Assert.Equal(CachingTypes.ReadOnly, dataDiskLun1.CachingType);
+                    Assert.Equal(100, dataDiskLun1.Size);
 
                     Assert.True(dataDisks.ContainsKey(2));
                     var dataDiskLun2 = dataDisks[2];
                     Assert.NotNull(dataDiskLun2.Id);
-                    Assert.Equal(dataDiskLun2.CachingType, CachingTypes.None);
-                    Assert.Equal(dataDiskLun2.Size, 150);
+                    Assert.Equal(CachingTypes.None, dataDiskLun2.CachingType);
+                    Assert.Equal(150, dataDiskLun2.Size);
 
                     Assert.True(dataDisks.ContainsKey(3));
                     var dataDiskLun3 = dataDisks[3];
                     Assert.NotNull(dataDiskLun3.Id);
-                    Assert.Equal(dataDiskLun3.CachingType, CachingTypes.None);
-                    Assert.Equal(dataDiskLun3.Size, 150);
+                    Assert.Equal(CachingTypes.None, dataDiskLun3.CachingType);
+                    Assert.Equal(150, dataDiskLun3.Size);
                     // Validate the defaults assigned
                     //
                     foreach (var dataDisk in dataDisks.Values)
                     {
                         if (dataDisk.Lun != 1 && dataDisk.Lun != 2 && dataDisk.Lun != 3)
                         {
-                            Assert.Equal(dataDisk.CachingType, CachingTypes.ReadWrite);
-                            Assert.Equal(dataDisk.StorageAccountType, StorageAccountTypes.StandardLRS);
+                            Assert.Equal(CachingTypes.ReadWrite, dataDisk.CachingType);
+                            Assert.Equal(StorageAccountTypes.StandardLRS, dataDisk.StorageAccountType);
                         }
                     }
 
@@ -339,12 +339,12 @@ namespace Fluent.Tests.Compute.VirtualMachine
                             .Create();
                     Assert.NotNull(customImage);
                     Assert.NotNull(customImage.SourceVirtualMachineId);
-                    Assert.True(customImage.SourceVirtualMachineId.Equals(virtualMachine1.Id, StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal(customImage.SourceVirtualMachineId, virtualMachine1.Id, ignoreCase: true);
                     Assert.NotNull(customImage.OSDiskImage);
-                    Assert.Equal(customImage.OSDiskImage.OsState, OperatingSystemStateTypes.Generalized);
-                    Assert.Equal(customImage.OSDiskImage.OsType, OperatingSystemTypes.Linux);
+                    Assert.Equal(OperatingSystemStateTypes.Generalized, customImage.OSDiskImage.OsState);
+                    Assert.Equal(OperatingSystemTypes.Linux, customImage.OSDiskImage.OsType);
                     Assert.NotNull(customImage.DataDiskImages);
-                    Assert.Equal(customImage.DataDiskImages.Count, 5);
+                    Assert.Equal(5, customImage.DataDiskImages.Count);
                     foreach (ImageDataDisk imageDataDisk in customImage.DataDiskImages.Values)
                     {
                         Assert.Null(imageDataDisk.BlobUri);
@@ -422,7 +422,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                     {
                         Assert.True(dataDisks.ContainsKey(imageDataDisk.Lun));
                         var dataDisk = dataDisks[imageDataDisk.Lun];
-                        Assert.Equal(dataDisk.CachingType, CachingTypes.ReadOnly);
+                        Assert.Equal(CachingTypes.ReadOnly, dataDisk.CachingType);
                         // Fails with new service.
                         //Assert.Equal(dataDisk.Size, (long)imageDataDisk.DiskSizeGB + 10);
                     }
@@ -515,7 +515,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
 
                     var dataDisks = virtualMachine1.DataDisks;
                     Assert.NotNull(dataDisks);
-                    Assert.Equal(dataDisks.Count, 5); // Removed one added another
+                    Assert.Equal(5, dataDisks.Count); // Removed one added another
                     Assert.True(dataDisks.ContainsKey(6));
                     Assert.False(dataDisks.ContainsKey(1));
                 }
@@ -589,7 +589,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                             .Create();
 
                     Assert.True(managedVM.IsManagedDiskEnabled);
-                    Assert.True(managedVM.OSDiskId.Equals(osDisk.Id, StringComparison.OrdinalIgnoreCase));
+                    Assert.Equal(managedVM.OSDiskId, osDisk.Id, ignoreCase: true);
                 }
                 finally
                 {

--- a/Tests/Fluent.Tests/Compute/VirtualMachineScaleSetManagedDiskOperationsTests.cs
+++ b/Tests/Fluent.Tests/Compute/VirtualMachineScaleSetManagedDiskOperationsTests.cs
@@ -72,9 +72,9 @@ namespace Fluent.Tests.Compute.VirtualMachine
                         Assert.False(vm.IsOSBasedOnStoredImage);
                         Assert.True(vm.IsManagedDiskEnabled);
                         Assert.NotNull(vm.UnmanagedDataDisks);
-                        Assert.Equal(vm.UnmanagedDataDisks.Count, 0);
+                        Assert.Empty(vm.UnmanagedDataDisks);
                         Assert.NotNull(vm.DataDisks);
-                        Assert.Equal(vm.DataDisks.Count, 3);
+                        Assert.Equal(3, vm.DataDisks.Count);
                     }
                     vmScaleSet.Update()
                             .WithoutDataDisk(0)
@@ -87,7 +87,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                     foreach (var vm in virtualMachines)
                     {
                         Assert.NotNull(vm.DataDisks);
-                        Assert.Equal(vm.DataDisks.Count, 3);
+                        Assert.Equal(3, vm.DataDisks.Count);
                     }
                 }
                 finally
@@ -191,15 +191,15 @@ namespace Fluent.Tests.Compute.VirtualMachine
                         Assert.False(vm1.IsOSBasedOnStoredImage);
                         Assert.True(vm1.IsManagedDiskEnabled);
                         Assert.NotNull(vm1.UnmanagedDataDisks);
-                        Assert.Equal(vm1.UnmanagedDataDisks.Count, 0);
+                        Assert.Empty(vm1.UnmanagedDataDisks);
                         Assert.NotNull(vm1.DataDisks);
-                        Assert.Equal(vm1.DataDisks.Count, 2); // Disks from data disk image from custom image
+                        Assert.Equal(2, vm1.DataDisks.Count); // Disks from data disk image from custom image
                         Assert.True(vm1.DataDisks.ContainsKey(1));
                         var disk = vm1.DataDisks[1];
-                        Assert.Equal(disk.Size, 100);
+                        Assert.Equal(100, disk.Size);
                         Assert.True(vm1.DataDisks.ContainsKey(2));
                         disk = vm1.DataDisks[2];
-                        Assert.Equal(disk.Size, 50);
+                        Assert.Equal(50, disk.Size);
                     }
 
                     vmScaleSet.Deallocate();

--- a/Tests/Fluent.Tests/Compute/VirtualMachinesTests.cs
+++ b/Tests/Fluent.Tests/Compute/VirtualMachinesTests.cs
@@ -149,7 +149,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                     Assert.True(powerState == PowerState.Running);
                     VirtualMachineInstanceView instanceView = foundedVM.InstanceView;
                     Assert.NotNull(instanceView);
-                    Assert.NotNull(instanceView.Statuses.Count > 0);
+                    Assert.NotEmpty(instanceView.Statuses);
 
                     // Capture the VM [Requires VM to be Poweroff and generalized]
                     foundedVM.PowerOff();
@@ -240,7 +240,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
 
                     foreach (var virtualMachine in createdVirtualMachines)
                     {
-                        Assert.True(virtualMachineNames.Contains(virtualMachine.Name));
+                        Assert.Contains(virtualMachine.Name, virtualMachineNames);
                         Assert.NotNull(virtualMachine.Id);
                     }
 
@@ -254,7 +254,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                     {
                         var createdNetwork = (INetwork)createdVirtualMachines.CreatedRelatedResource(networkCreatableKey);
                         Assert.NotNull(createdNetwork);
-                        Assert.True(networkNames.Contains(createdNetwork.Name));
+                        Assert.Contains(createdNetwork.Name, networkNames);
                     }
 
                     HashSet<string> publicIPAddressNames = new HashSet<string>();
@@ -267,7 +267,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                     {
                         var createdPublicIPAddress = (IPublicIPAddress)createdVirtualMachines.CreatedRelatedResource(publicIPCreatableKey);
                         Assert.NotNull(createdPublicIPAddress);
-                        Assert.True(publicIPAddressNames.Contains(createdPublicIPAddress.Name));
+                        Assert.Contains(createdPublicIPAddress.Name, publicIPAddressNames);
                     }
                 }
                 finally
@@ -322,7 +322,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                 {
                     var commandOutput = TestHelper.TrySsh(publicIPAddress.Fqdn, 22, username, password, "pwgen;");
 
-                    Assert.False(commandOutput.ToLowerInvariant().Contains("the program 'pwgen' is currently not installed"));
+                    Assert.DoesNotContain("the program 'pwgen' is currently not installed", commandOutput.ToLowerInvariant());
                 }
             }
         }
@@ -529,7 +529,7 @@ namespace Fluent.Tests.Compute.VirtualMachine
                 Assert.Equal(1, unmanagedDataDisks.Count);
                 firstUnmanagedDataDisk = unmanagedDataDisks.First().Value;
                 Assert.NotNull(firstUnmanagedDataDisk.VhdUri);
-                Assert.True(firstUnmanagedDataDisk.VhdUri.Equals(createdVhdUri1, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal(firstUnmanagedDataDisk.VhdUri, createdVhdUri1, ignoreCase: true);
                 // Update the VM by attaching another existing data disk
                 //
                 virtualMachine.Update()

--- a/Tests/Fluent.Tests/KeyVault/KeyVaultTests.cs
+++ b/Tests/Fluent.Tests/KeyVault/KeyVaultTests.cs
@@ -97,7 +97,7 @@ namespace Fluent.Tests
                     manager.Vaults.DeleteById(vault2.Id);
 
                     vaults = manager.Vaults.ListByResourceGroup(rgName);
-                    Assert.Equal(0, vaults.Count());
+                    Assert.Empty(vaults);
                 }
                 finally
                 {

--- a/Tests/Fluent.Tests/Miscellaneous/RestClientTests.cs
+++ b/Tests/Fluent.Tests/Miscellaneous/RestClientTests.cs
@@ -53,7 +53,7 @@ namespace Fluent.Tests.Miscellaneous
                        .WithNewResourceGroup(rgName)
                        .Create();
 
-                    Assert.True(string.Equals(storageAccount.ResourceGroupName, rgName));
+                    Assert.Equal(storageAccount.ResourceGroupName, rgName);
                 }
                 finally
                 {

--- a/Tests/Fluent.Tests/Network/ApplicationGateway/PrivateComplex.cs
+++ b/Tests/Fluent.Tests/Network/ApplicationGateway/PrivateComplex.cs
@@ -126,30 +126,30 @@ namespace Fluent.Tests.Network.ApplicationGateway
             Assert.NotNull(appGateway);
             Assert.Equal(ApplicationGatewayTier.Standard, appGateway.Tier);
             Assert.Equal(ApplicationGatewaySkuName.StandardMedium, appGateway.Size);
-            Assert.Equal(appGateway.InstanceCount, 2);
+            Assert.Equal(2, appGateway.InstanceCount);
             Assert.False(appGateway.IsPublic);
             Assert.True(appGateway.IsPrivate);
-            Assert.Equal(appGateway.IPConfigurations.Count, 1);
+            Assert.Equal(1, appGateway.IPConfigurations.Count);
 
             // Verify frontend ports
-            Assert.Equal(appGateway.FrontendPorts.Count, 3);
+            Assert.Equal(3, appGateway.FrontendPorts.Count);
             Assert.NotNull(appGateway.FrontendPortNameFromNumber(80));
             Assert.NotNull(appGateway.FrontendPortNameFromNumber(443));
             Assert.NotNull(appGateway.FrontendPortNameFromNumber(9000));
 
             // Verify frontends
-            Assert.Equal(appGateway.Frontends.Count, 1);
-            Assert.Equal(appGateway.PublicFrontends.Count, 0);
-            Assert.Equal(appGateway.PrivateFrontends.Count, 1);
+            Assert.Equal(1, appGateway.Frontends.Count);
+            Assert.Equal(0, appGateway.PublicFrontends.Count);
+            Assert.Equal(1, appGateway.PrivateFrontends.Count);
             IApplicationGatewayFrontend frontend = appGateway.PrivateFrontends.Values.First();
             Assert.False(frontend.IsPublic);
             Assert.True(frontend.IsPrivate);
 
             // Verify listeners
-            Assert.Equal(appGateway.Listeners.Count, 3);
+            Assert.Equal(3, appGateway.Listeners.Count);
             IApplicationGatewayListener listener = appGateway.Listeners["listener1"];
             Assert.NotNull(listener);
-            Assert.Equal(listener.FrontendPortNumber, 9000);
+            Assert.Equal(9000, listener.FrontendPortNumber);
             Assert.Equal(ApplicationGatewayProtocol.Http, listener.Protocol);
             Assert.NotNull(listener.Frontend);
             Assert.True(listener.Frontend.IsPrivate);
@@ -158,61 +158,61 @@ namespace Fluent.Tests.Network.ApplicationGateway
             Assert.NotNull(appGateway.ListenerByPortNumber(443));
 
             // Verify certificates
-            Assert.Equal(appGateway.SslCertificates.Count, 2);
+            Assert.Equal(2, appGateway.SslCertificates.Count);
             Assert.True(appGateway.SslCertificates.ContainsKey("cert1"));
 
             // Verify backend HTTP settings configs
-            Assert.Equal(appGateway.BackendHttpConfigurations.Count, 3);
+            Assert.Equal(3, appGateway.BackendHttpConfigurations.Count);
             IApplicationGatewayBackendHttpConfiguration config = appGateway.BackendHttpConfigurations["config1"];
             Assert.NotNull(config);
-            Assert.Equal(config.Port, 8081);
-            Assert.Equal(config.RequestTimeout, 45);
+            Assert.Equal(8081, config.Port);
+            Assert.Equal(45, config.RequestTimeout);
             Assert.True(appGateway.BackendHttpConfigurations.ContainsKey("config2"));
 
             // Verify backends
-            Assert.Equal(appGateway.Backends.Count, 3);
+            Assert.Equal(3, appGateway.Backends.Count);
             IApplicationGatewayBackend backend = appGateway.Backends["backend1"];
             Assert.NotNull(backend);
-            Assert.Equal(backend.Addresses.Count, 2);
+            Assert.Equal(2, backend.Addresses.Count);
             Assert.True(backend.ContainsIPAddress("11.1.1.3"));
             Assert.True(backend.ContainsIPAddress("11.1.1.4"));
             Assert.True(appGateway.Backends.ContainsKey("backend2"));
 
             // Verify request routing rules
-            Assert.Equal(appGateway.RequestRoutingRules.Count, 3);
+            Assert.Equal(3, appGateway.RequestRoutingRules.Count);
             IApplicationGatewayRequestRoutingRule rule;
 
             rule = appGateway.RequestRoutingRules["rule80"];
             Assert.NotNull(rule);
             Assert.Equal(vnet.Id, rule.Listener.Frontend.NetworkId);
-            Assert.Equal(rule.FrontendPort, 80);
-            Assert.Equal(rule.BackendPort, 8080);
+            Assert.Equal(80, rule.FrontendPort);
+            Assert.Equal(8080, rule.BackendPort);
             Assert.True(rule.CookieBasedAffinity);
-            Assert.Equal(rule.BackendAddresses.Count, 2);
+            Assert.Equal(2, rule.BackendAddresses.Count);
             Assert.True(rule.Backend.ContainsIPAddress("11.1.1.1"));
             Assert.True(rule.Backend.ContainsIPAddress("11.1.1.2"));
 
             rule = appGateway.RequestRoutingRules["rule443"];
             Assert.NotNull(rule);
             Assert.Equal(vnet.Id, rule.Listener.Frontend.NetworkId);
-            Assert.Equal(rule.FrontendPort, 443);
+            Assert.Equal(443, rule.FrontendPort);
             Assert.Equal(ApplicationGatewayProtocol.Https, rule.FrontendProtocol);
             Assert.NotNull(rule.SslCertificate);
             Assert.NotNull(rule.BackendHttpConfiguration);
-            Assert.Equal(rule.BackendHttpConfiguration.Name, "config1");
+            Assert.Equal("config1", rule.BackendHttpConfiguration.Name);
             Assert.NotNull(rule.Backend);
-            Assert.Equal(rule.Backend.Name, "backend1");
+            Assert.Equal("backend1", rule.Backend.Name);
 
             rule = appGateway.RequestRoutingRules["rule9000"];
             Assert.NotNull(rule);
             Assert.NotNull(rule.Listener);
-            Assert.Equal(rule.Listener.Name, "listener1");
+            Assert.Equal("listener1", rule.Listener.Name);
             Assert.NotNull(rule.Listener.SubnetName);
             Assert.NotNull(rule.Listener.NetworkId);
             Assert.NotNull(rule.BackendHttpConfiguration);
-            Assert.Equal(rule.BackendHttpConfiguration.Name, "config1");
+            Assert.Equal("config1", rule.BackendHttpConfiguration.Name);
             Assert.NotNull(rule.Backend);
-            Assert.Equal(rule.Backend.Name, "backend1");
+            Assert.Equal("backend1", rule.Backend.Name);
 
             creationThread.Join();
 
@@ -266,7 +266,7 @@ namespace Fluent.Tests.Network.ApplicationGateway
             Assert.True(resource.Tags.ContainsKey("tag1"));
             Assert.True(resource.Tags.ContainsKey("tag2"));
             Assert.Equal(ApplicationGatewaySkuName.StandardSmall, resource.Size);
-            Assert.Equal(resource.InstanceCount, 1);
+            Assert.Equal(1, resource.InstanceCount);
 
             // Verify frontend ports
             Assert.Equal(resource.FrontendPorts.Count, portCount - 1);
@@ -274,8 +274,8 @@ namespace Fluent.Tests.Network.ApplicationGateway
 
             // Verify frontends
             Assert.Equal(resource.Frontends.Count, frontendCount + 1);
-            Assert.Equal(resource.PublicFrontends.Count, 1);
-            Assert.Equal(resource.PrivateFrontends.Count, 1);
+            Assert.Equal(1, resource.PublicFrontends.Count);
+            Assert.Equal(1, resource.PrivateFrontends.Count);
             IApplicationGatewayFrontend frontend = resource.PrivateFrontends.Values.First();
             Assert.True(!frontend.IsPublic);
             Assert.True(frontend.IsPrivate);
@@ -289,7 +289,7 @@ namespace Fluent.Tests.Network.ApplicationGateway
             Assert.True(!resource.Backends.ContainsKey("backend2"));
             IApplicationGatewayBackend backend = resource.Backends["backend1"];
             Assert.NotNull(backend);
-            Assert.Equal(backend.Addresses.Count, 1);
+            Assert.Equal(1, backend.Addresses.Count);
             Assert.True(backend.ContainsIPAddress("11.1.1.5"));
             Assert.True(!backend.ContainsIPAddress("11.1.1.3"));
             Assert.True(!backend.ContainsIPAddress("11.1.1.4"));
@@ -298,8 +298,8 @@ namespace Fluent.Tests.Network.ApplicationGateway
             Assert.Equal(resource.BackendHttpConfigurations.Count, configCount - 1);
             Assert.True(!resource.BackendHttpConfigurations.ContainsKey("config2"));
             IApplicationGatewayBackendHttpConfiguration config = resource.BackendHttpConfigurations["config1"];
-            Assert.Equal(config.Port, 8082);
-            Assert.Equal(config.RequestTimeout, 20);
+            Assert.Equal(8082, config.Port);
+            Assert.Equal(20, config.RequestTimeout);
             Assert.True(config.CookieBasedAffinity);
 
             // Verify rules

--- a/Tests/Fluent.Tests/Network/PublicIpAddressTests.cs
+++ b/Tests/Fluent.Tests/Network/PublicIpAddressTests.cs
@@ -43,7 +43,7 @@ namespace Fluent.Tests.Network
                         .WithTag("tag1", "value1")
                         .WithTag("tag2", "value2")
                         .Apply();
-                Assert.True(resource.LeafDomainLabel.Equals(updatedDnsName, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal(resource.LeafDomainLabel, updatedDnsName, ignoreCase: true);
                 Assert.True(resource.IdleTimeoutInMinutes == updatedIdleTimeout);
 
                 manager.PublicIPAddresses.DeleteById(pip.Id);

--- a/Tests/Fluent.Tests/Redis/RedisCacheTests.cs
+++ b/Tests/Fluent.Tests/Redis/RedisCacheTests.cs
@@ -75,7 +75,7 @@ namespace Fluent.Tests
                     {
                         Assert.True(false);
                     }
-                    Assert.Equal(1, redisCaches.Count());
+                    Assert.Single(redisCaches);
 
                     // List all Redis resources
                     redisCaches = redisManager.RedisCaches.List();

--- a/Tests/Fluent.Tests/ServiceBus/ServiceBusTests.cs
+++ b/Tests/Fluent.Tests/ServiceBus/ServiceBusTests.cs
@@ -57,7 +57,6 @@ namespace Fluent.Tests
                     Assert.True(nspace.Region.Equals(region));
                     Assert.NotNull(nspace.ResourceGroupName);
                     Assert.Equal(nspace.ResourceGroupName, rgName, ignoreCase: true);
-                    Assert.NotNull(nspace.CreatedAt);
                     Assert.NotNull(nspace.Queues);
                     Assert.Empty(nspace.Queues.List());
                     Assert.NotNull(nspace.Topics);
@@ -135,13 +134,11 @@ namespace Fluent.Tests
                     Assert.Equal(60, queue.LockDurationInSeconds);
 
                     var dupDetectionDuration = queue.DuplicateMessageDetectionHistoryDuration;
-                    Assert.NotNull(dupDetectionDuration);
                     Assert.Equal(10, dupDetectionDuration.TotalMinutes);
                     // Default message TTL is TimeSpan.Max, assert parsing
                     //
                     Assert.Equal("10675199.02:48:05.4775807", queue.Inner.DefaultMessageTimeToLive);
                     var msgTtlDuration = queue.DefaultMessageTtlDuration;
-                    Assert.NotNull(msgTtlDuration);
                     // Assert the default ttl TimeSpan("10675199.02:48:05.4775807") parsing
                     //
                     Assert.Equal(10675199, msgTtlDuration.Days);
@@ -291,13 +288,11 @@ namespace Fluent.Tests
                     Assert.Equal(topic.Name, topicName, ignoreCase: true);
 
                     var dupDetectionDuration = topic.DuplicateMessageDetectionHistoryDuration;
-                    Assert.NotNull(dupDetectionDuration);
                     Assert.Equal(10, dupDetectionDuration.TotalMinutes);
                     // Default message TTL is TimeSpan.Max, assert parsing
                     //
                     Assert.Equal("10675199.02:48:05.4775807", topic.Inner.DefaultMessageTimeToLive);
                     var msgTtlDuration = topic.DefaultMessageTtlDuration;
-                    Assert.NotNull(msgTtlDuration);
                     // Assert the default ttl TimeSpan("10675199.02:48:05.4775807") parsing
                     //
                     Assert.Equal(10675199, msgTtlDuration.Days);
@@ -318,10 +313,8 @@ namespace Fluent.Tests
                             .WithDeleteOnIdleDurationInMinutes(25)
                             .Apply();
                     var ttlDuration = foundTopic.DefaultMessageTtlDuration;
-                    Assert.NotNull(ttlDuration);
                     Assert.Equal(20, ttlDuration.Minutes);
                     var duplicateDetectDuration = foundTopic.DuplicateMessageDetectionHistoryDuration;
-                    Assert.NotNull(duplicateDetectDuration);
                     Assert.Equal(15, duplicateDetectDuration.Minutes);
                     Assert.Equal(25, foundTopic.DeleteOnIdleDurationInMinutes);
                     // Delete

--- a/Tests/Fluent.Tests/Sql/SqlTests.cs
+++ b/Tests/Fluent.Tests/Sql/SqlTests.cs
@@ -358,8 +358,6 @@ namespace Fluent.Tests
 
                 // Test transparent data encryption settings.
                 var transparentDataEncryption = sqlDatabase.GetTransparentDataEncryption();
-                Assert.NotNull(transparentDataEncryption.Status);
-
                 var transparentDataEncryptionActivities = transparentDataEncryption.ListActivities();
                 Assert.NotNull(transparentDataEncryptionActivities);
 
@@ -872,7 +870,6 @@ namespace Fluent.Tests
             Assert.Equal(elasticPoolName, sqlElasticPool.Name);
             Assert.Equal(SqlServerName, sqlElasticPool.SqlServerName);
             Assert.Equal(ElasticPoolEditions.Standard, sqlElasticPool.Edition);
-            Assert.NotNull(sqlElasticPool.CreationDate);
             Assert.NotEqual(0, sqlElasticPool.DatabaseDtuMax);
             Assert.NotEqual(0, sqlElasticPool.Dtu);
         }

--- a/src/ResourceManagement/Compute/ContainerServiceAgentPoolImpl.cs
+++ b/src/ResourceManagement/Compute/ContainerServiceAgentPoolImpl.cs
@@ -41,8 +41,6 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         {
             this.Inner.DnsPrefix = param0;
             return this;
-
-            return this;
         }
 
         public string VMSize()

--- a/src/ResourceManagement/Network/Domain/InterfaceImpl/LocalNetworkGatewayImpl.cs
+++ b/src/ResourceManagement/Network/Domain/InterfaceImpl/LocalNetworkGatewayImpl.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         /// Remove address space. Note: address space will be removed only in case of exact cidr string match.
         /// </summary>
         /// <param name="cidr">The CIDR representation of the local network site address space.</param>
+        /// <return>The next stage of the update.</return>
         LocalNetworkGateway.Update.IUpdate LocalNetworkGateway.Update.IWithAddressSpace.WithoutAddressSpace(string cidr)
         {
             return this.WithoutAddressSpace(cidr) as LocalNetworkGateway.Update.IUpdate;
@@ -26,6 +27,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         /// Note: this method's effect is additive, i.e. each time it is used, a new address space is added to the network.
         /// </summary>
         /// <param name="cidr">The CIDR representation of the local network site address space.</param>
+        /// <return>The next stage of the update.</return>
         LocalNetworkGateway.Update.IUpdate LocalNetworkGateway.Update.IWithAddressSpace.WithAddressSpace(string cidr)
         {
             return this.WithAddressSpace(cidr) as LocalNetworkGateway.Update.IUpdate;
@@ -90,28 +92,42 @@ namespace Microsoft.Azure.Management.Network.Fluent
             return this.WithIPAddress(ipAddress) as LocalNetworkGateway.Update.IUpdate;
         }
 
+        /// <summary>
+        /// Specifies the IP address of the local network gateway.
+        /// </summary>
+        /// <param name="ipAddress">An IP address.</param>
+        /// <return>The next stage of the definition.</return>
         LocalNetworkGateway.Definition.IWithAddressSpace LocalNetworkGateway.Definition.IWithIPAddress.WithIPAddress(string ipAddress)
         {
             return this.WithIPAddress(ipAddress) as LocalNetworkGateway.Definition.IWithAddressSpace;
         }
 
+        /// <summary>
+        /// Enables BGP.
+        /// </summary>
         /// <param name="asn">The BGP speaker's ASN.</param>
         /// <param name="bgpPeeringAddress">The BGP peering address and BGP identifier of this BGP speaker.</param>
+        /// <return>The next stage of the update.</return>
         LocalNetworkGateway.Update.IUpdate LocalNetworkGateway.Update.IWithBgp.WithBgp(long asn, string bgpPeeringAddress)
         {
             return this.WithBgp(asn, bgpPeeringAddress) as LocalNetworkGateway.Update.IUpdate;
         }
 
-        LocalNetworkGateway.Update.IUpdate LocalNetworkGateway.Update.IWithBgp.DisableBgp
+        /// <summary>
+        /// Disables BGP.
+        /// </summary>
+        /// <return>The next stage of the update.</return>
+        LocalNetworkGateway.Update.IUpdate LocalNetworkGateway.Update.IWithBgp.WithoutBgp()
         {
-            get
-            {
-                return this.DisableBgp() as LocalNetworkGateway.Update.IUpdate;
-            }
+            return this.WithoutBgp() as LocalNetworkGateway.Update.IUpdate;
         }
 
+        /// <summary>
+        /// Enables BGP.
+        /// </summary>
         /// <param name="asn">The BGP speaker's ASN.</param>
         /// <param name="bgpPeeringAddress">The BGP peering address and BGP identifier of this BGP speaker.</param>
+        /// <return>The next stage of the definition.</return>
         LocalNetworkGateway.Definition.IWithCreate LocalNetworkGateway.Definition.IWithBgp.WithBgp(long asn, string bgpPeeringAddress)
         {
             return this.WithBgp(asn, bgpPeeringAddress) as LocalNetworkGateway.Definition.IWithCreate;

--- a/src/ResourceManagement/Network/Domain/InterfaceImpl/VirtualNetworkGatewayImpl.cs
+++ b/src/ResourceManagement/Network/Domain/InterfaceImpl/VirtualNetworkGatewayImpl.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Azure.Management.Network.Fluent
         /// virtual network gateway, it will be created with the specified address space and a subnet for virtual network gateway.
         /// </summary>
         /// <param name="name">The name of the new virtual network.</param>
-        /// <param name="addressSpace">The address space for rhe virtual network.</param>
+        /// <param name="addressSpace">The address space for the virtual network.</param>
+        /// <param name="subnetAddressSpaceCidr">The address space for the subnet.</param>
         /// <return>The next stage of the definition.</return>
         VirtualNetworkGateway.Definition.IWithGatewayType VirtualNetworkGateway.Definition.IWithNetwork.WithNewNetwork(string name, string addressSpace, string subnetAddressSpaceCidr)
         {
@@ -45,6 +46,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         /// it will be created with the specified address space and a default subnet for virtual network gateway.
         /// </summary>
         /// <param name="addressSpaceCidr">The address space for the virtual network.</param>
+        /// <param name="subnetAddressSpaceCidr">The address space for the subnet.</param>
         /// <return>The next stage of the definition.</return>
         VirtualNetworkGateway.Definition.IWithGatewayType VirtualNetworkGateway.Definition.IWithNetwork.WithNewNetwork(string addressSpaceCidr, string subnetAddressSpaceCidr)
         {
@@ -283,24 +285,27 @@ namespace Microsoft.Azure.Management.Network.Fluent
 
         /// <param name="asn">The BGP speaker's ASN.</param>
         /// <param name="bgpPeeringAddress">The BGP peering address and BGP identifier of this BGP speaker.</param>
+        /// <return>The next stage of the definition.</return>
         VirtualNetworkGateway.Definition.IWithCreate VirtualNetworkGateway.Definition.IWithBgp.WithBgp(long asn, string bgpPeeringAddress)
         {
             return this.WithBgp(asn, bgpPeeringAddress) as VirtualNetworkGateway.Definition.IWithCreate;
         }
 
         /// <summary>
-        /// Gets Disable BGP for this virtual network gateway.
+        /// Disables BGP for this virtual network gateway.
         /// </summary>
-        VirtualNetworkGateway.Update.IUpdate VirtualNetworkGateway.Update.IWithBgp.DisableBgp
+        /// <return>The next stage of the update.</return>
+        VirtualNetworkGateway.Update.IUpdate VirtualNetworkGateway.Update.IWithBgp.WithoutBgp()
         {
-            get
-            {
-                return this.DisableBgp() as VirtualNetworkGateway.Update.IUpdate;
-            }
+            return this.WithoutBgp() as VirtualNetworkGateway.Update.IUpdate;
         }
 
+        /// <summary>
+        /// Enables BGP.
+        /// </summary>
         /// <param name="asn">The BGP speaker's ASN.</param>
         /// <param name="bgpPeeringAddress">The BGP peering address and BGP identifier of this BGP speaker.</param>
+        /// <return>The next stage of the update.</return>
         VirtualNetworkGateway.Update.IUpdate VirtualNetworkGateway.Update.IWithBgp.WithBgp(long asn, string bgpPeeringAddress)
         {
             return this.WithBgp(asn, bgpPeeringAddress) as VirtualNetworkGateway.Update.IUpdate;

--- a/src/ResourceManagement/Network/Domain/LocalNetworkGateway/Definition/IDefinition.cs
+++ b/src/ResourceManagement/Network/Domain/LocalNetworkGateway/Definition/IDefinition.cs
@@ -2,26 +2,41 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition
 {
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition;
-    using Microsoft.Azure.Management.Network.Fluent;
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.GroupableResource.Definition;
+    using Microsoft.Azure.Management.Network.Fluent;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
+
+    /// <summary>
+    /// The entirety of the local network gateway definition.
+    /// </summary>
+    public interface IDefinition  :
+        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IBlank,
+        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithGroup,
+        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithIPAddress,
+        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithCreate
+    {
+    }
 
     /// <summary>
     /// The stage of definition allowing to specify local network gateway's BGP speaker settings.
     /// </summary>
     public interface IWithBgp 
     {
+        /// <summary>
+        /// Enables BGP.
+        /// </summary>
         /// <param name="asn">The BGP speaker's ASN.</param>
         /// <param name="bgpPeeringAddress">The BGP peering address and BGP identifier of this BGP speaker.</param>
+        /// <return>The next stage of the definition.</return>
         Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithCreate WithBgp(long asn, string bgpPeeringAddress);
     }
 
     /// <summary>
-    /// The first stage of a local network gateway definition.
+    /// The stage of the local network gateway definition allowing to specify the resource group.
     /// </summary>
-    public interface IBlank  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition.IDefinitionWithRegion<Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithGroup>
+    public interface IWithGroup  :
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.GroupableResource.Definition.IWithGroup<Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithIPAddress>
     {
     }
 
@@ -34,17 +49,6 @@ namespace Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definiti
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition.IDefinitionWithTags<Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithCreate>,
         Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithAddressSpace,
         Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithBgp
-    {
-    }
-
-    /// <summary>
-    /// The entirety of the local network gateway definition.
-    /// </summary>
-    public interface IDefinition  :
-        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IBlank,
-        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithGroup,
-        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithIPAddress,
-        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithCreate
     {
     }
 
@@ -62,10 +66,10 @@ namespace Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definiti
     }
 
     /// <summary>
-    /// The stage of the local network gateway definition allowing to specify the resource group.
+    /// The first stage of a local network gateway definition.
     /// </summary>
-    public interface IWithGroup  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.GroupableResource.Definition.IWithGroup<Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithIPAddress>
+    public interface IBlank  :
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition.IDefinitionWithRegion<Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithGroup>
     {
     }
 
@@ -74,6 +78,11 @@ namespace Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definiti
     /// </summary>
     public interface IWithIPAddress 
     {
+        /// <summary>
+        /// Specifies the IP address of the local network gateway.
+        /// </summary>
+        /// <param name="ipAddress">An IP address.</param>
+        /// <return>The next stage of the definition.</return>
         Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Definition.IWithAddressSpace WithIPAddress(string ipAddress);
     }
 }

--- a/src/ResourceManagement/Network/Domain/LocalNetworkGateway/Update/IUpdate.cs
+++ b/src/ResourceManagement/Network/Domain/LocalNetworkGateway/Update/IUpdate.cs
@@ -7,6 +7,26 @@ namespace Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
 
     /// <summary>
+    /// The stage of update allowing to specify local network gateway's BGP speaker settings.
+    /// </summary>
+    public interface IWithBgp 
+    {
+        /// <summary>
+        /// Enables BGP.
+        /// </summary>
+        /// <param name="asn">The BGP speaker's ASN.</param>
+        /// <param name="bgpPeeringAddress">The BGP peering address and BGP identifier of this BGP speaker.</param>
+        /// <return>The next stage of the update.</return>
+        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update.IUpdate WithBgp(long asn, string bgpPeeringAddress);
+
+        /// <summary>
+        /// Disables BGP.
+        /// </summary>
+        /// <return>The next stage of the update.</return>
+        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update.IUpdate WithoutBgp();
+    }
+
+    /// <summary>
     /// The stage of the local network gateway update allowing to specify the address spaces.
     /// </summary>
     public interface IWithAddressSpace 
@@ -15,6 +35,7 @@ namespace Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update
         /// Remove address space. Note: address space will be removed only in case of exact cidr string match.
         /// </summary>
         /// <param name="cidr">The CIDR representation of the local network site address space.</param>
+        /// <return>The next stage of the update.</return>
         Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update.IUpdate WithoutAddressSpace(string cidr);
 
         /// <summary>
@@ -22,33 +43,13 @@ namespace Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update
         /// Note: this method's effect is additive, i.e. each time it is used, a new address space is added to the network.
         /// </summary>
         /// <param name="cidr">The CIDR representation of the local network site address space.</param>
+        /// <return>The next stage of the update.</return>
         Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update.IUpdate WithAddressSpace(string cidr);
-    }
-
-    /// <summary>
-    /// The stage of update allowing to specify local network gateway's BGP speaker settings.
-    /// </summary>
-    public interface IWithBgp 
-    {
-        /// <param name="asn">The BGP speaker's ASN.</param>
-        /// <param name="bgpPeeringAddress">The BGP peering address and BGP identifier of this BGP speaker.</param>
-        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update.IUpdate WithBgp(long asn, string bgpPeeringAddress);
-
-        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update.IUpdate DisableBgp { get; }
-    }
-
-    /// <summary>
-    /// The stage of the local network gateway update allowing to change IP address of local network gateway.
-    /// </summary>
-    public interface IWithIPAddress 
-    {
-        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update.IUpdate WithIPAddress(string ipAddress);
     }
 
     /// <summary>
     /// The template for a local network gateway update operation, containing all the settings that
     /// can be modified.
-    /// Call  Update.apply() to apply the changes to the resource in Azure.
     /// </summary>
     public interface IUpdate  :
         Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.Network.Fluent.ILocalNetworkGateway>,
@@ -57,5 +58,13 @@ namespace Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update
         Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update.IWithAddressSpace,
         Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update.IWithBgp
     {
+    }
+
+    /// <summary>
+    /// The stage of the local network gateway update allowing to change IP address of local network gateway.
+    /// </summary>
+    public interface IWithIPAddress 
+    {
+        Microsoft.Azure.Management.Network.Fluent.LocalNetworkGateway.Update.IUpdate WithIPAddress(string ipAddress);
     }
 }

--- a/src/ResourceManagement/Network/Domain/VirtualNetworkGateway/Definition/IDefinition.cs
+++ b/src/ResourceManagement/Network/Domain/VirtualNetworkGateway/Definition/IDefinition.cs
@@ -2,31 +2,34 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition
 {
-    using Microsoft.Azure.Management.Network.Fluent;
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition;
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
-    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.GroupableResource.Definition;
-    using Microsoft.Azure.Management.Network.Fluent.HasPublicIPAddress.Definition;
     using Microsoft.Azure.Management.Network.Fluent.Models;
+    using Microsoft.Azure.Management.Network.Fluent.HasPublicIPAddress.Definition;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.GroupableResource.Definition;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition;
+    using Microsoft.Azure.Management.Network.Fluent;
+    using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
 
     /// <summary>
-    /// The stage of the virtual network gateway definition which contains all the minimum required inputs for
-    /// the resource to be created (via  WithCreate.create()), but also allows
-    /// for any other optional settings to be specified.
+    /// The stage of virtual network gateway definition allowing to specify SKU.
     /// </summary>
-    public interface IWithCreate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.Network.Fluent.IVirtualNetworkGateway>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition.IDefinitionWithTags<Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithCreate>,
-        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithPublicIPAddress,
-        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithBgp
+    public interface IWithSku 
+    {
+        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithCreate WithSku(VirtualNetworkGatewaySkuName skuName);
+    }
+
+    /// <summary>
+    /// The stage of virtual network gateway definition allowing to specify public IP address for IP configuration.
+    /// </summary>
+    public interface IWithPublicIPAddress  :
+        Microsoft.Azure.Management.Network.Fluent.HasPublicIPAddress.Definition.IWithPublicIPAddressNoDnsLabel<Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithCreate>
     {
     }
 
     /// <summary>
-    /// The first stage of a virtual network gateway definition.
+    /// The stage of the virtual network gateway definition allowing to specify the resource group.
     /// </summary>
-    public interface IBlank  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition.IDefinitionWithRegion<Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithGroup>
+    public interface IWithGroup  :
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.GroupableResource.Definition.IWithGroup<Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithNetwork>
     {
     }
 
@@ -45,18 +48,10 @@ namespace Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Defini
     }
 
     /// <summary>
-    /// The stage of the virtual network gateway definition allowing to specify the resource group.
+    /// The first stage of a virtual network gateway definition.
     /// </summary>
-    public interface IWithGroup  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.GroupableResource.Definition.IWithGroup<Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithNetwork>
-    {
-    }
-
-    /// <summary>
-    /// The stage of virtual network gateway definition allowing to specify public IP address for IP configuration.
-    /// </summary>
-    public interface IWithPublicIPAddress  :
-        Microsoft.Azure.Management.Network.Fluent.HasPublicIPAddress.Definition.IWithPublicIPAddressNoDnsLabel<Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithCreate>
+    public interface IBlank  :
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition.IDefinitionWithRegion<Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithGroup>
     {
     }
 
@@ -68,6 +63,7 @@ namespace Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Defini
     {
         /// <param name="asn">The BGP speaker's ASN.</param>
         /// <param name="bgpPeeringAddress">The BGP peering address and BGP identifier of this BGP speaker.</param>
+        /// <return>The next stage of the definition.</return>
         Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithCreate WithBgp(long asn, string bgpPeeringAddress);
     }
 
@@ -96,6 +92,19 @@ namespace Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Defini
     }
 
     /// <summary>
+    /// The stage of the virtual network gateway definition which contains all the minimum required inputs for
+    /// the resource to be created, but also allows
+    /// for any other optional settings to be specified.
+    /// </summary>
+    public interface IWithCreate  :
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.ICreatable<Microsoft.Azure.Management.Network.Fluent.IVirtualNetworkGateway>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Definition.IDefinitionWithTags<Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithCreate>,
+        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithPublicIPAddress,
+        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithBgp
+    {
+    }
+
+    /// <summary>
     /// The stage of the virtual network gateway definition allowing to specify the virtual network.
     /// </summary>
     public interface IWithNetwork 
@@ -114,7 +123,8 @@ namespace Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Defini
         /// virtual network gateway, it will be created with the specified address space and a subnet for virtual network gateway.
         /// </summary>
         /// <param name="name">The name of the new virtual network.</param>
-        /// <param name="addressSpace">The address space for rhe virtual network.</param>
+        /// <param name="addressSpace">The address space for the virtual network.</param>
+        /// <param name="subnetAddressSpaceCidr">The address space for the subnet.</param>
         /// <return>The next stage of the definition.</return>
         Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithGatewayType WithNewNetwork(string name, string addressSpace, string subnetAddressSpaceCidr);
 
@@ -124,6 +134,7 @@ namespace Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Defini
         /// it will be created with the specified address space and a default subnet for virtual network gateway.
         /// </summary>
         /// <param name="addressSpaceCidr">The address space for the virtual network.</param>
+        /// <param name="subnetAddressSpaceCidr">The address space for the subnet.</param>
         /// <return>The next stage of the definition.</return>
         Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithGatewayType WithNewNetwork(string addressSpaceCidr, string subnetAddressSpaceCidr);
 
@@ -133,13 +144,5 @@ namespace Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Defini
         /// <param name="network">An existing virtual network.</param>
         /// <return>The next stage of the definition.</return>
         Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithGatewayType WithExistingNetwork(INetwork network);
-    }
-
-    /// <summary>
-    /// The stage of virtual network gateway definition allowing to specify SKU.
-    /// </summary>
-    public interface IWithSku 
-    {
-        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Definition.IWithCreate WithSku(VirtualNetworkGatewaySkuName skuName);
     }
 }

--- a/src/ResourceManagement/Network/Domain/VirtualNetworkGateway/Update/IUpdate.cs
+++ b/src/ResourceManagement/Network/Domain/VirtualNetworkGateway/Update/IUpdate.cs
@@ -2,10 +2,22 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 namespace Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update
 {
-    using Microsoft.Azure.Management.Network.Fluent.Models;
     using Microsoft.Azure.Management.Network.Fluent;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Update;
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions;
+    using Microsoft.Azure.Management.Network.Fluent.Models;
+
+    /// <summary>
+    /// The template for a virtual network gateway update operation, containing all the settings that
+    /// can be modified.
+    /// </summary>
+    public interface IUpdate  :
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.Network.Fluent.IVirtualNetworkGateway>,
+        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Update.IUpdateWithTags<Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update.IUpdate>,
+        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update.IWithSku,
+        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update.IWithBgp
+    {
+    }
 
     /// <summary>
     /// The stage of update allowing to specify virtual network gateway's BGP speaker settings.
@@ -13,14 +25,19 @@ namespace Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update
     /// </summary>
     public interface IWithBgp 
     {
+        /// <summary>
+        /// Enables BGP.
+        /// </summary>
         /// <param name="asn">The BGP speaker's ASN.</param>
         /// <param name="bgpPeeringAddress">The BGP peering address and BGP identifier of this BGP speaker.</param>
+        /// <return>The next stage of the update.</return>
         Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update.IUpdate WithBgp(long asn, string bgpPeeringAddress);
 
         /// <summary>
-        /// Gets Disable BGP for this virtual network gateway.
+        /// Disables BGP for this virtual network gateway.
         /// </summary>
-        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update.IUpdate DisableBgp { get; }
+        /// <return>The next stage of the update.</return>
+        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update.IUpdate WithoutBgp();
     }
 
     /// <summary>
@@ -29,18 +46,5 @@ namespace Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update
     public interface IWithSku 
     {
         Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update.IUpdate WithSku(VirtualNetworkGatewaySkuName skuName);
-    }
-
-    /// <summary>
-    /// The template for a virtual network gateway update operation, containing all the settings that
-    /// can be modified.
-    /// Call  Update.apply() to apply the changes to the resource in Azure.
-    /// </summary>
-    public interface IUpdate  :
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IAppliable<Microsoft.Azure.Management.Network.Fluent.IVirtualNetworkGateway>,
-        Microsoft.Azure.Management.ResourceManager.Fluent.Core.Resource.Update.IUpdateWithTags<Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update.IUpdate>,
-        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update.IWithSku,
-        Microsoft.Azure.Management.Network.Fluent.VirtualNetworkGateway.Update.IWithBgp
-    {
     }
 }

--- a/src/ResourceManagement/Network/LocalNetworkGatewayImpl.cs
+++ b/src/ResourceManagement/Network/LocalNetworkGatewayImpl.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Azure.Management.Network.Fluent
             return this;
         }
 
-        ///GENMHASH:D747AFA75EF01A631FD1E74DD4950F8C:CBF36D794E88BFED53AE4DC92C5109ED
-        public LocalNetworkGatewayImpl DisableBgp()
+        ///GENMHASH:6E2DB095301FA5F54EABD8841D651031:CBF36D794E88BFED53AE4DC92C5109ED
+        public LocalNetworkGatewayImpl WithoutBgp()
         {
             Inner.BgpSettings = null;
             return this;
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:0202A00A1DCF248D2647DBDBEF2CA865:D2A6D2A6D9D7D04639AA5B3E46602E45
-        public async override Task<Microsoft.Azure.Management.Network.Fluent.ILocalNetworkGateway> CreateResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
+        public async override Task<ILocalNetworkGateway> CreateResourceAsync(CancellationToken cancellationToken = default(CancellationToken))
         {
             var response = await Manager.Inner.LocalNetworkGateways.CreateOrUpdateAsync(ResourceGroupName, Name, Inner);
             SetInner(response);

--- a/src/ResourceManagement/Network/VirtualNetworkGatewayConnectionImpl.cs
+++ b/src/ResourceManagement/Network/VirtualNetworkGatewayConnectionImpl.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
 
         protected async override Task<IVirtualNetworkGatewayConnection> CreateChildResourceAsync(CancellationToken cancellationToken = new CancellationToken())
         {
-            CreateResourceAsync(cancellationToken);
+            await CreateResourceAsync(cancellationToken);
             return this;
         }
 

--- a/src/ResourceManagement/Network/VirtualNetworkGatewayImpl.cs
+++ b/src/ResourceManagement/Network/VirtualNetworkGatewayImpl.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         }
 
         ///GENMHASH:D747AFA75EF01A631FD1E74DD4950F8C:6ECEFC402E9AA9F35C569FFECCCFB74C
-        public VirtualNetworkGatewayImpl DisableBgp()
+        public VirtualNetworkGatewayImpl WithoutBgp()
         {
             Inner.BgpSettings = null;
             Inner.EnableBgp = false;

--- a/src/ResourceManagement/ServiceBus/QueueImpl.cs
+++ b/src/ResourceManagement/ServiceBus/QueueImpl.cs
@@ -9,11 +9,8 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
     using System.Collections.Generic;
     using System;
     using Management.ServiceBus.Fluent.Models;
-    using ServiceBus.Fluent;
     using ResourceManager.Fluent.Core;
     using ResourceManager.Fluent.Core.ResourceActions;
-    using Management.ServiceBus.Fluent;
-    using System.Linq;
 
     /// <summary>
     /// Implementation for Queue.
@@ -31,7 +28,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
         IDefinition,
         IUpdate
     {
-        private IList<ICreatable<Microsoft.Azure.Management.ServiceBus.Fluent.IQueueAuthorizationRule>> rulesToCreate;
+        private IList<ICreatable<IQueueAuthorizationRule>> rulesToCreate;
         private IList<string> rulesToDelete;
 
         ///GENMHASH:2E16A3C3DDA5707111D704BA0D4871AD:E384D1DC0323D2359E002A2334C75FD1


### PR DESCRIPTION
- Cleanup of miscellaneous compiler warnings
- Documentation fixes in networking

compat breaks from previous beta:
- DisableBgp() renamed as WithoutBgp() in fluent update flows for virtual and local network gateways
