### PR TITLE
Enable User Assigned Identity in MSITokenProvider

### DIFF
--- a/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
         public AzureCredentials(MSILoginInformation msiLoginInformation, AzureEnvironment environment)
             : this(tenantId: null, environment: environment)
         {
-            this.msiTokenProvider = new MSITokenProvider(environment.ResourceManagerEndpoint, msiLoginInformation.Port);
+            this.msiTokenProvider = new MSITokenProvider(environment.ResourceManagerEndpoint, msiLoginInformation);
         }
 
         private AzureCredentials(string tenantId, AzureEnvironment environment)

--- a/src/ResourceManagement/ResourceManager/Authentication/MSILoginInformation.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/MSILoginInformation.cs
@@ -2,11 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
 {
@@ -15,7 +10,34 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
     /// </summary>
     public class MSILoginInformation : IBeta
     {
-        public int Port
+        /// <summary>
+        /// Get or Set the MSI extension port to retrieve access token from.
+        /// </summary>
+        public int? Port
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Get or Set the Active Directory Client ID associated with the user assigned identity.
+        /// </summary>
+        public string UserAssignedIdentityClientId
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Get or Set user assigned identity resource ARM id.
+        /// </summary>
+        public string UserAssignedIdentityResourceId
+        {
+            get; set;
+        }
+
+        /// <summary>
+        /// Get or Set the Active Directory Object ID associated with the user assigned identity.
+        /// </summary>
+        public string UserAssignedIdentityObjectId
         {
             get; set;
         }


### PR DESCRIPTION
Current MSITokenProvider supports only System Assigned MSI, updating provider to support User Assigned Identity MSI as well