### PR TITLE
Adding StorageAccountTypes::Standard_ZRS

### DIFF
--- a/src/ResourceManagement/Compute/Generated/Models/StorageAccountTypes.cs
+++ b/src/ResourceManagement/Compute/Generated/Models/StorageAccountTypes.cs
@@ -24,7 +24,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent.Models
         [EnumMember(Value = "Premium_LRS")]
         PremiumLRS,
         [EnumMember(Value = "StandardSSD_LRS")]
-        StandardSSDLRS
+        StandardSSDLRS,
+        [EnumMember(Value = "Standard_ZRS")]
+        StandardZRS
     }
     internal static class StorageAccountTypesEnumExtension
     {
@@ -41,6 +43,10 @@ namespace Microsoft.Azure.Management.Compute.Fluent.Models
                     return "Standard_LRS";
                 case StorageAccountTypes.PremiumLRS:
                     return "Premium_LRS";
+                case StorageAccountTypes.StandardSSDLRS:
+                    return "StandardSSD_LRS";
+                case StorageAccountTypes.StandardZRS:
+                    return "Standard_ZRS";
             }
             return null;
         }
@@ -53,6 +59,11 @@ namespace Microsoft.Azure.Management.Compute.Fluent.Models
                     return StorageAccountTypes.StandardLRS;
                 case "Premium_LRS":
                     return StorageAccountTypes.PremiumLRS;
+                case "StandardSSD_LRS":
+                    return StorageAccountTypes.StandardSSDLRS;
+                case "Standard_ZRS":
+                    return StorageAccountTypes.StandardZRS;
+
             }
             return null;
         }


### PR DESCRIPTION
Related to the issue described in this [PR](https://github.com/Azure/azure-libraries-for-net/pull/144)

While testing with different subscriptions, found that there is one more enum value `Standard_ZRS`, this PR add that value as well. Update the [issue](https://github.com/Azure/azure-rest-api-specs/issues/2343) in the api spec.