### PR TITLE
Fixed issue where netstandard doesn't get the correct token for the graph endpoint

### DIFF
--- a/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
                     else
                     {
                         credentialsCache[adSettings.TokenAudience] = await ApplicationTokenProvider.LoginSilentAsync(
-                            TenantId, servicePrincipalLoginInformation.ClientId, servicePrincipalLoginInformation.Certificate, servicePrincipalLoginInformation.CertificatePassword, TokenCache.DefaultShared);
+                            TenantId, servicePrincipalLoginInformation.ClientId, servicePrincipalLoginInformation.Certificate, servicePrincipalLoginInformation.CertificatePassword, adSettings, TokenCache.DefaultShared);
                     }
                 }
 #if !PORTABLE


### PR DESCRIPTION
Without this the token sent to the graph endpoint doesn't work on .net standard.
Looks like an oversight in the code. See issue here:

https://github.com/Azure/azure-libraries-for-net/issues/104
