### PR TITLE
Support custom\external ServiceClientCredentials

### DIFF
--- a/src/ResourceManagement/Compute/ComputeManager.cs
+++ b/src/ResourceManagement/Compute/ComputeManager.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         {
             storageManager = StorageManager.Authenticate(restClient, subscriptionId);
             networkManager = NetworkManager.Authenticate(restClient, subscriptionId);
-            rbacManager = GraphRbacManager.Authenticate(restClient, ((AzureCredentials)(restClient.Credentials)).TenantId);
+            rbacManager = GraphRbacManager.Authenticate(restClient, restClient.Credentials.TenantId);
         }
 
         #endregion

--- a/src/ResourceManagement/Graph.RBAC/CertificateCredentialImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/CertificateCredentialImpl.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             AzureEnvironment environment = null;
             if (restClient.Credentials is AzureCredentials)
             {
-                environment = ((AzureCredentials)restClient.Credentials).Environment;
+                environment = restClient.Credentials.Environment;
             }
             else
             {

--- a/src/ResourceManagement/Graph.RBAC/GraphRBACManager.cs
+++ b/src/ResourceManagement/Graph.RBAC/GraphRBACManager.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             string graphEndpoint = AzureEnvironment.AzureGlobalCloud.GraphEndpoint;
             if (restClient.Credentials is AzureCredentials)
             {
-                graphEndpoint = ((AzureCredentials)restClient.Credentials).Environment.GraphEndpoint;
+                graphEndpoint = restClient.Credentials.Environment.GraphEndpoint;
             }
             inner = new GraphRbacManagementClient(new Uri(graphEndpoint),
                 restClient.Credentials,

--- a/src/ResourceManagement/Graph.RBAC/PasswordCredentialImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/PasswordCredentialImpl.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             AzureEnvironment environment = null;
             if (restClient.Credentials is AzureCredentials)
             {
-                environment = ((AzureCredentials)restClient.Credentials).Environment;
+                environment = restClient.Credentials.Environment;
             }
             else
             {

--- a/src/ResourceManagement/Msi/MsiManager.cs
+++ b/src/ResourceManagement/Msi/MsiManager.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Management.Msi.Fluent
                 SubscriptionId = subscriptionId
             })
         {
-            this.graphRbacManager = Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManager.Authenticate(restClient, ((AzureCredentials)(restClient.Credentials)).TenantId);
+            this.graphRbacManager = Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManager.Authenticate(restClient, restClient.Credentials.TenantId);
         }
 
         #region MsiManager builder

--- a/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
@@ -64,6 +64,12 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
             this.msiTokenProviderFactory = new MSITokenProviderFactory(msiLoginInformation);
         }
 
+        public AzureCredentials(ServiceClientCredentials credentials, string tenantId, AzureEnvironment environment)
+            : this(tenantId, environment)
+        {
+            credentialsCache[new Uri(Environment.ManagementEndpoint)] = credentials;
+        }
+
         private AzureCredentials(string tenantId, AzureEnvironment environment)
         {
             TenantId = tenantId;

--- a/src/ResourceManagement/ResourceManager/Core/RestClient/RestClient.cs
+++ b/src/ResourceManagement/ResourceManager/Core/RestClient/RestClient.cs
@@ -11,6 +11,7 @@ using System.Net.Http;
 using System.Net.NetworkInformation;
 using System.Security.Cryptography;
 using System.Text;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
 
 namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 {
@@ -37,7 +38,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
             get; private set;
         }
 
-        public ServiceClientCredentials Credentials
+        public AzureCredentials Credentials
         {
             get; private set;
         }
@@ -77,7 +78,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
         public class RestClientBuilder : RestClientBuilder.IBlank, RestClientBuilder.IBuildable
         {
             private string baseUri;
-            private ServiceClientCredentials credentials;
+            private AzureCredentials credentials;
             private List<DelegatingHandler> handlers;
             private RetryPolicy retryPolicy;
             private HttpLoggingDelegatingHandler loggingDelegatingHandler;
@@ -155,7 +156,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
                 IBuildable WithLogLevel(HttpLoggingDelegatingHandler.Level level);
 
-                IBuildable WithCredentials(ServiceClientCredentials credentials);
+                IBuildable WithCredentials(AzureCredentials credentials);
 
                 RestClient Build();
             }
@@ -214,7 +215,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                 return this;
             }
 
-            public IBuildable WithCredentials(ServiceClientCredentials credentials)
+            public IBuildable WithCredentials(AzureCredentials credentials)
             {
                 this.credentials = credentials;
                 return this;


### PR DESCRIPTION
A number of the managers downcast the `RestClient`'s `Credentials` to `AzureCredentials` (eg https://github.com/Azure/azure-libraries-for-net/blob/master/src/ResourceManagement/Compute/ComputeManager.cs#L46).  Combined with the public facing side of the API accepting `ServiceClientCredentials` as input, we end up with an unfortunate violation of Liskov Substitution Principal that means code like this doesn't work;

```
// using Microsoft.Azure.Services.AppAuthentication(Prerelease)
var azureServiceTokenProvider = new AzureServiceTokenProvider();
var token = await azureServiceTokenProvider.GetAccessTokenAsync("https://management.core.windows.net/");
var tenantId = azureServiceTokenProvider.PrincipalUsed.TenantId;

var client = RestClient
	.Configure()
	.WithEnvironment(AzureEnvironment.AzureGlobalCloud)
	.WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
	.WithCredentials(new TokenCredentials(token))
	.Build();

// throws "Unable to cast object of type 'Microsoft.Rest.TokenCredentials' to type 'Microsoft.Azure.Management.ResourceManager.Fluent.Authentication.AzureCredentials'."
var azure = Azure
	.Authenticate(client, tenantId)
	.WithDefaultSubscription();
```

This change moves us "all in" on the `AzureCredentials` usage on the `RestClient` and provides consumers a new (working) way to inject custom `ServiceClientCredentials` via a new constructor on `AzureCredentials`.

This is a breaking change from an API signature perspective, but as per the example above, I expect any code that was supplying ServiceClientCredentials would be broken anyway.