### PR TITLE
CosmosDB fixed null primaryReadonlyMasterKey and secondaryReadonlyMas…

### DIFF
--- a/src/ResourceManagement/CosmosDB/Generated/Models/DatabaseAccountListKeysResultInner.cs
+++ b/src/ResourceManagement/CosmosDB/Generated/Models/DatabaseAccountListKeysResultInner.cs
@@ -73,13 +73,13 @@ namespace Microsoft.Azure.Management.CosmosDB.Fluent.Models
         /// <summary>
         /// Gets base 64 encoded value of the primary read-only key.
         /// </summary>
-        [JsonProperty(PropertyName = "properties.primaryReadonlyMasterKey")]
+        [JsonProperty(PropertyName = "primaryReadonlyMasterKey")]
         public string PrimaryReadonlyMasterKey { get; private set; }
 
         /// <summary>
         /// Gets base 64 encoded value of the secondary read-only key.
         /// </summary>
-        [JsonProperty(PropertyName = "properties.secondaryReadonlyMasterKey")]
+        [JsonProperty(PropertyName = "secondaryReadonlyMasterKey")]
         public string SecondaryReadonlyMasterKey { get; private set; }
 
     }


### PR DESCRIPTION
CosmosDB, fixed null primaryReadonlyMasterKey and secondaryReadonlyMasterKey.

The problem is probably coming from the documentation, where the client code is generated from:

https://docs.microsoft.com/en-us/rest/api/documentdbresourceprovider/databaseaccounts/listkeys

the API 2015-04-08 is returning the following object back: 
{
  "primaryMasterKey": "theprimarykey",
  "secondaryMasterKey": "thesecondarykey",
  "primaryReadonlyMasterKey": "theprimaryReadonlyMasterKey",
  "secondaryReadonlyMasterKey": "thesecondaryReadonlyMasterKey"
}

and NOT as described:
{
  "primaryMasterKey": "primaryMasterKey",
  "secondaryMasterKey": "secondaryMasterKey",
  "properties": {
    "primaryReadonlyMasterKey": "primaryReadonlyMasterKey",
    "secondaryReadonlyMasterKey": "secondaryReadonlyMasterKey"
  }
}



