### PR TITLE
Add support for reading SSL certificate from Pfx file during Application gateway update stage

### DIFF
--- a/Tests/Fluent.Tests/Network/ApplicationGateway/PrivateMinimal.cs
+++ b/Tests/Fluent.Tests/Network/ApplicationGateway/PrivateMinimal.cs
@@ -103,12 +103,15 @@ namespace Fluent.Tests.Network.ApplicationGateway
                 .WithSize(ApplicationGatewaySkuName.StandardMedium)
                 .WithFrontendPort(81, "port81")         // Add a new port
                 .WithoutBackendIPAddress("11.1.1.1")    // Remove from all existing backends
+                .DefineSslCertificate("testSSL")
+                    .WithPfxFromFile(new FileInfo(Path.Combine("Assets", "myTest._pfx")))
+                    .WithPfxPassword("Abc123")
+                    .Attach()
                 .DefineListener("listener2")
                     .WithPrivateFrontend()
                     .WithFrontendPort(81)
                     .WithHttps()
-                    .WithSslCertificateFromPfxFile(new FileInfo(Path.Combine("Assets", "myTest._pfx")))
-                    .WithSslCertificatePassword("Abc123")
+                    .WithSslCertificate("testSSL")
                     .Attach()
                 .DefineBackend("backend2")
                     .WithIPAddress("11.1.1.3")

--- a/src/ResourceManagement/Network/Domain/ApplicationGatewaySslCertificate/UpdateDefinition/IUpdateDefinition.cs
+++ b/src/ResourceManagement/Network/Domain/ApplicationGatewaySslCertificate/UpdateDefinition/IUpdateDefinition.cs
@@ -11,7 +11,9 @@ namespace Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertifi
     /// <typeparam name="ParentT">The stage of the parent application gateway definition to return to after attaching.</typeparam>
     public interface IUpdateDefinition<ParentT> :
         Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertificate.UpdateDefinition.IBlank<ParentT>,
-        Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertificate.UpdateDefinition.IWithAttach<ParentT>
+        Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertificate.UpdateDefinition.IWithAttach<ParentT>,
+        Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertificate.UpdateDefinition.IWithData<ParentT>,
+        Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertificate.UpdateDefinition.IWithPassword<ParentT>
     {
     }
 

--- a/src/ResourceManagement/Network/Domain/ApplicationGatewaySslCertificate/UpdateDefinition/IUpdateDefinition.cs
+++ b/src/ResourceManagement/Network/Domain/ApplicationGatewaySslCertificate/UpdateDefinition/IUpdateDefinition.cs
@@ -3,6 +3,7 @@
 namespace Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertificate.UpdateDefinition
 {
     using Microsoft.Azure.Management.ResourceManager.Fluent.Core.ChildResource.Update;
+    using System.IO;
 
     /// <summary>
     /// The entirety of an application gateway SSL certificate definition as part of an application gateway update.
@@ -25,12 +26,49 @@ namespace Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertifi
     {
     }
 
+
+    /// <summary>
+    /// The stage of an SSL certificate definition allowing to specify the password for the private key (PFX) content of the certificate.
+    /// </summary>
+    /// <typeparam name="ParentT">The stage of the parent application gateway to return to after attaching.</typeparam>
+    public interface IWithPassword<ParentT>
+    {
+        /// <summary>
+        /// Specifies the password currently used to protect the provided PFX content of the SSL certificate.
+        /// </summary>
+        /// <param name="password">A password.</param>
+        /// <return>The next stage of the definition.</return>
+        Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertificate.UpdateDefinition.IWithAttach<ParentT> WithPfxPassword(string password);
+    }
+
+    /// <summary>
+    /// The stage of an SSL certificate definition allowing to specify the contents of the SSL certificate.
+    /// </summary>
+    /// <typeparam name="ParentT">The stage of the parent application gateway to return to after attaching.</typeparam>
+    public interface IWithData<ParentT>
+    {
+        /// <summary>
+        /// Specifies the PFX (PKCS#12) file to get the private key content from.
+        /// </summary>
+        /// <param name="pfxFile">A file in the PFX format.</param>
+        /// <return>The next stage of the definition.</return>
+        /// <throws>Java.io.IOException when there are problems with the provided file.</throws>
+        Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertificate.UpdateDefinition.IWithPassword<ParentT> WithPfxFromFile(FileInfo pfxFile);
+
+        /// <summary>
+        /// Specifies the contents of the private key in the PFX (PKCS#12) format, not base64-encoded.
+        /// </summary>
+        /// <param name="pfxData">The contents of the private key in the PFX format.</param>
+        /// <return>The next stage of the definition.</return>
+        Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertificate.UpdateDefinition.IWithPassword<ParentT> WithPfxFromBytes(params byte[] pfxData);
+    }
+
     /// <summary>
     /// The first stage of an application gateway authentication certificate definition.
     /// </summary>
     /// <typeparam name="ParentT">The stage of the parent application gateway definition to return to after attaching.</typeparam>
     public interface IBlank<ParentT> :
-        Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertificate.UpdateDefinition.IWithAttach<ParentT>
+        Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaySslCertificate.UpdateDefinition.IWithData<ParentT>
     {
     }
 }

--- a/src/ResourceManagement/Network/Domain/InterfaceImpl/ApplicationGatewaySslCertificateImpl.cs
+++ b/src/ResourceManagement/Network/Domain/InterfaceImpl/ApplicationGatewaySslCertificateImpl.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
         /// </summary>
         /// <param name="pfxFile">A file in the PFX format.</param>
         /// <return>The next stage of the definition.</return>
-        /// <throws>Java.io.IOException when there are problems with the provided file.</throws>
+        /// <throws>System.IO.IOException when there are problems with the provided file.</throws>
         ApplicationGatewaySslCertificate.UpdateDefinition.IWithPassword<ApplicationGateway.Update.IUpdate> ApplicationGatewaySslCertificate.UpdateDefinition.IWithData<ApplicationGateway.Update.IUpdate>.WithPfxFromFile(FileInfo pfxFile)
         {
             return this.WithPfxFromFile(pfxFile) as ApplicationGatewaySslCertificate.UpdateDefinition.IWithPassword<ApplicationGateway.Update.IUpdate>;
@@ -108,5 +108,14 @@ namespace Microsoft.Azure.Management.Network.Fluent
             return this.WithPfxFromBytes(pfxData) as ApplicationGatewaySslCertificate.UpdateDefinition.IWithPassword<ApplicationGateway.Update.IUpdate>;
         }
 
+        /// <summary>
+        /// Specifies the password currently used to protect the provided PFX content of the SSL certificate.
+        /// </summary>
+        /// <param name="password">A password.</param>
+        /// <return>The next stage of the definition.</return>
+        ApplicationGatewaySslCertificate.UpdateDefinition.IWithAttach<ApplicationGateway.Update.IUpdate> ApplicationGatewaySslCertificate.UpdateDefinition.IWithPassword<ApplicationGateway.Update.IUpdate>.WithPfxPassword(string password)
+        {
+            return this.WithPfxPassword(password) as ApplicationGatewaySslCertificate.UpdateDefinition.IWithAttach<ApplicationGateway.Update.IUpdate>;
+        }
     }
 }

--- a/src/ResourceManagement/Network/Domain/InterfaceImpl/ApplicationGatewaySslCertificateImpl.cs
+++ b/src/ResourceManagement/Network/Domain/InterfaceImpl/ApplicationGatewaySslCertificateImpl.cs
@@ -85,5 +85,28 @@ namespace Microsoft.Azure.Management.Network.Fluent
         {
             return this.WithPfxPassword(password) as ApplicationGatewaySslCertificate.Definition.IWithAttach<ApplicationGateway.Definition.IWithCreate>;
         }
+
+
+        /// <summary>
+        /// Specifies the PFX (PKCS#12) file to get the private key content from.
+        /// </summary>
+        /// <param name="pfxFile">A file in the PFX format.</param>
+        /// <return>The next stage of the definition.</return>
+        /// <throws>Java.io.IOException when there are problems with the provided file.</throws>
+        ApplicationGatewaySslCertificate.UpdateDefinition.IWithPassword<ApplicationGateway.Update.IUpdate> ApplicationGatewaySslCertificate.UpdateDefinition.IWithData<ApplicationGateway.Update.IUpdate>.WithPfxFromFile(FileInfo pfxFile)
+        {
+            return this.WithPfxFromFile(pfxFile) as ApplicationGatewaySslCertificate.UpdateDefinition.IWithPassword<ApplicationGateway.Update.IUpdate>;
+        }
+
+        /// <summary>
+        /// Specifies the password currently used to protect the provided PFX content of the SSL certificate.
+        /// </summary>
+        /// <param name="password">A password.</param>
+        /// <return>The next stage of the definition.</return>
+        ApplicationGatewaySslCertificate.UpdateDefinition.IWithPassword<ApplicationGateway.Update.IUpdate> ApplicationGatewaySslCertificate.UpdateDefinition.IWithData<ApplicationGateway.Update.IUpdate>.WithPfxFromBytes(params byte[] pfxData)
+        {
+            return this.WithPfxFromBytes(pfxData) as ApplicationGatewaySslCertificate.UpdateDefinition.IWithPassword<ApplicationGateway.Update.IUpdate>;
+        }
+
     }
 }


### PR DESCRIPTION
Prior to this PR, IBlank<ParentT> interface in IUpdateDefinition.cs wasn't correctly implemented; so we had no way of adding data to an SSL certificate in the Application gateway's update stage.
See #257 