### PR TITLE
SQL: always pass "Accept" JSON header as part of the REST call

### DIFF
--- a/src/ResourceManagement/Sql/Generated/BackupLongTermRetentionPoliciesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/BackupLongTermRetentionPoliciesOperations.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -385,6 +386,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -604,6 +606,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/BackupLongTermRetentionVaultsOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/BackupLongTermRetentionVaultsOperations.cs
@@ -143,6 +143,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -364,6 +365,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -575,6 +577,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/CapabilitiesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/CapabilitiesOperations.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/DataMaskingPoliciesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/DataMaskingPoliciesOperations.cs
@@ -164,6 +164,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -377,6 +378,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/DataMaskingRulesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/DataMaskingRulesOperations.cs
@@ -173,6 +173,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -404,6 +405,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/DatabaseAutomaticTuningOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/DatabaseAutomaticTuningOperations.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -361,6 +362,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/DatabaseBlobAuditingPoliciesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/DatabaseBlobAuditingPoliciesOperations.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -372,6 +373,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/DatabaseThreatDetectionPoliciesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/DatabaseThreatDetectionPoliciesOperations.cs
@@ -153,6 +153,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -373,6 +374,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/DatabaseUsagesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/DatabaseUsagesOperations.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ElasticPoolActivitiesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ElasticPoolActivitiesOperations.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ElasticPoolDatabaseActivitiesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ElasticPoolDatabaseActivitiesOperations.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/EncryptionProtectorsOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/EncryptionProtectorsOperations.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -338,6 +339,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -574,6 +576,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -753,6 +756,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/FailoverGroupsOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/FailoverGroupsOperations.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -428,6 +429,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -697,6 +699,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -922,6 +925,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1116,6 +1120,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1326,6 +1331,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1531,6 +1537,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1704,6 +1711,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/GeoBackupPoliciesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/GeoBackupPoliciesOperations.cs
@@ -159,6 +159,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -390,6 +391,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -594,6 +596,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/Operations.cs
+++ b/src/ResourceManagement/Sql/Generated/Operations.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -283,6 +284,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/RecommendedElasticPoolsOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/RecommendedElasticPoolsOperations.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -344,6 +345,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -548,6 +550,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/RecoverableDatabasesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/RecoverableDatabasesOperations.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -345,6 +346,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ReplicationLinksOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ReplicationLinksOperations.cs
@@ -155,6 +155,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -350,6 +351,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -614,6 +616,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -825,6 +828,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1018,6 +1022,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/RestorableDroppedDatabasesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/RestorableDroppedDatabasesOperations.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -345,6 +346,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/RestorePointsOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/RestorePointsOperations.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -391,6 +392,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -608,6 +610,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ServerAutomaticTuningOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ServerAutomaticTuningOperations.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -343,6 +344,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ServerAzureADAdministratorsOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ServerAzureADAdministratorsOperations.cs
@@ -194,6 +194,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -389,6 +390,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -601,6 +603,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -841,6 +844,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ServerCommunicationLinksOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ServerCommunicationLinksOperations.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -332,6 +333,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -556,6 +558,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -773,6 +776,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ServerConnectionPoliciesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ServerConnectionPoliciesOperations.cs
@@ -150,6 +150,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -372,6 +373,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ServerDnsAliasesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ServerDnsAliasesOperations.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -396,6 +397,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -630,6 +632,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -849,6 +852,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1042,6 +1046,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1203,6 +1208,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ServerKeysOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ServerKeysOperations.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -344,6 +345,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -625,6 +627,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -850,6 +853,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1005,6 +1009,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ServerUsagesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ServerUsagesOperations.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ServersOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ServersOperations.cs
@@ -134,6 +134,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -316,6 +317,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -502,6 +504,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -697,6 +700,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -979,6 +983,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1195,6 +1200,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1380,6 +1386,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1559,6 +1566,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1732,6 +1740,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ServiceObjectivesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ServiceObjectivesOperations.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -344,6 +345,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/ServiceTierAdvisorsOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/ServiceTierAdvisorsOperations.cs
@@ -158,6 +158,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -362,6 +363,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/SubscriptionUsagesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/SubscriptionUsagesOperations.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -324,6 +325,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -497,6 +499,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/SyncAgentsOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/SyncAgentsOperations.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -399,6 +400,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -603,6 +605,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -807,6 +810,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1020,6 +1024,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1245,6 +1250,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1400,6 +1406,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1573,6 +1580,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/SyncGroupsOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/SyncGroupsOperations.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -372,6 +373,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -630,6 +632,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -840,6 +843,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1032,6 +1036,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1227,6 +1232,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1524,6 +1530,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1734,6 +1741,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1937,6 +1945,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -2171,6 +2180,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -2374,6 +2384,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -2553,6 +2564,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -2726,6 +2738,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -2899,6 +2912,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -3072,6 +3086,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/SyncMembersOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/SyncMembersOperations.cs
@@ -167,6 +167,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -482,6 +483,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -704,6 +706,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -966,6 +969,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1209,6 +1213,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1421,6 +1426,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1646,6 +1652,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1801,6 +1808,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -1974,6 +1982,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/TransparentDataEncryptionActivitiesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/TransparentDataEncryptionActivitiesOperations.cs
@@ -152,6 +152,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/TransparentDataEncryptionsOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/TransparentDataEncryptionsOperations.cs
@@ -163,6 +163,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -394,6 +395,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)

--- a/src/ResourceManagement/Sql/Generated/VirtualNetworkRulesOperations.cs
+++ b/src/ResourceManagement/Sql/Generated/VirtualNetworkRulesOperations.cs
@@ -149,6 +149,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -399,6 +400,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -615,6 +617,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -840,6 +843,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)
@@ -995,6 +999,7 @@ namespace Microsoft.Azure.Management.Sql.Fluent
                 }
                 _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
+            _httpRequest.Headers.TryAddWithoutValidation("Accept", "application/json");
 
 
             if (customHeaders != null)


### PR DESCRIPTION
This is a fix/work around for SQL operations failing when called from .NET Fluent SDK on Linux or Mac environment.