### PR TITLE
Remove topicName max length validation in  SubscriptionsOperations

### DIFF
--- a/src/ResourceManagement/ServiceBus/Generated/SubscriptionsOperations.cs
+++ b/src/ResourceManagement/ServiceBus/Generated/SubscriptionsOperations.cs
@@ -122,10 +122,6 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
             }
             if (topicName != null)
             {
-                if (topicName.Length > 50)
-                {
-                    throw new ValidationException(ValidationRules.MaxLength, "topicName", 50);
-                }
                 if (topicName.Length < 1)
                 {
                     throw new ValidationException(ValidationRules.MinLength, "topicName", 1);
@@ -367,10 +363,6 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
             }
             if (topicName != null)
             {
-                if (topicName.Length > 50)
-                {
-                    throw new ValidationException(ValidationRules.MaxLength, "topicName", 50);
-                }
                 if (topicName.Length < 1)
                 {
                     throw new ValidationException(ValidationRules.MinLength, "topicName", 1);
@@ -634,10 +626,6 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
             }
             if (topicName != null)
             {
-                if (topicName.Length > 50)
-                {
-                    throw new ValidationException(ValidationRules.MaxLength, "topicName", 50);
-                }
                 if (topicName.Length < 1)
                 {
                     throw new ValidationException(ValidationRules.MinLength, "topicName", 1);
@@ -875,10 +863,6 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
             }
             if (topicName != null)
             {
-                if (topicName.Length > 50)
-                {
-                    throw new ValidationException(ValidationRules.MaxLength, "topicName", 50);
-                }
                 if (topicName.Length < 1)
                 {
                     throw new ValidationException(ValidationRules.MinLength, "topicName", 1);


### PR DESCRIPTION
it was already removed in a previous PR for topic and queueoperations
- see https://github.com/Azure/azure-libraries-for-net/pull/188
but not from SubscriptionsOperations
this PR removes this limit as well 