### PR TITLE
Fixing operations with ActiveDirectoryApplication with multiple credentials with same name

### DIFF
--- a/Tests/Fluent.Tests/GraphRbac/ApplicationsTests.cs
+++ b/Tests/Fluent.Tests/GraphRbac/ApplicationsTests.cs
@@ -43,12 +43,17 @@ namespace Fluent.Tests.Graph.RBAC
                                 .WithPublicKey(File.ReadAllBytes("Assets/myTest.cer"))
                                 .WithDuration(TimeSpan.FromDays(100))
                                 .Attach()
+                            .DefineCertificateCredential("cert")
+                                .WithAsymmetricX509Certificate()
+                                .WithPublicKey(File.ReadAllBytes("Assets/myTest2.cer"))
+                                .WithDuration(TimeSpan.FromDays(80))
+                                .Attach()
                             .Create();
                     Console.WriteLine(application.Id + " - " + application.ApplicationId);
                     Assert.NotNull(application.Id);
                     Assert.NotNull(application.ApplicationId);
                     Assert.Equal(name, application.Name);
-                    Assert.Equal(1, application.CertificateCredentials.Count);
+                    Assert.Equal(2, application.CertificateCredentials.Count);
                     Assert.Equal(1, application.PasswordCredentials.Count);
                     Assert.Equal(1, application.ReplyUrls.Count);
                     Assert.Equal(1, application.IdentifierUris.Count);

--- a/Tests/Fluent.Tests/GraphRbac/ServicePrincipalsTests.cs
+++ b/Tests/Fluent.Tests/GraphRbac/ServicePrincipalsTests.cs
@@ -37,13 +37,18 @@ namespace Fluent.Tests.Graph.RBAC
                             .DefinePasswordCredential("sppass")
                                 .WithPasswordValue("StrongPass!12")
                                 .Attach()
+                            .DefineCertificateCredential("spcert")
+                                .WithAsymmetricX509Certificate()
+                                .WithPublicKey(File.ReadAllBytes("Assets/myTest.cer"))
+                                .WithDuration(TimeSpan.FromDays(1))
+                                .Attach()
                             .Create();
                     Console.WriteLine(servicePrincipal.Id + " - " + string.Join(", ", servicePrincipal.ServicePrincipalNames));
                     Assert.NotNull(servicePrincipal.Id);
                     Assert.NotNull(servicePrincipal.ApplicationId);
                     Assert.Equal(2, servicePrincipal.ServicePrincipalNames.Count);
                     Assert.Equal(1, servicePrincipal.PasswordCredentials.Count);
-                    Assert.Equal(0, servicePrincipal.CertificateCredentials.Count);
+                    Assert.Equal(1, servicePrincipal.CertificateCredentials.Count);
 
                     // Get
                     servicePrincipal = manager.ServicePrincipals.GetByName(servicePrincipal.ApplicationId);
@@ -51,22 +56,22 @@ namespace Fluent.Tests.Graph.RBAC
                     Assert.NotNull(servicePrincipal.ApplicationId);
                     Assert.Equal(2, servicePrincipal.ServicePrincipalNames.Count);
                     Assert.Equal(1, servicePrincipal.PasswordCredentials.Count);
-                    Assert.Equal(0, servicePrincipal.CertificateCredentials.Count);
+                    Assert.Equal(1, servicePrincipal.CertificateCredentials.Count);
 
                     // Update
                     servicePrincipal.Update()
                             .WithoutCredential("sppass")
                             .DefineCertificateCredential("spcert")
                                 .WithAsymmetricX509Certificate()
-                                .WithPublicKey(File.ReadAllBytes("Assets/myTest.cer"))
-                                .WithDuration(TimeSpan.FromDays(1))
+                                .WithPublicKey(File.ReadAllBytes("Assets/myTest2.cer"))
+                                .WithDuration(TimeSpan.FromDays(2))
                                 .Attach()
                             .Apply();
                     Assert.NotNull(servicePrincipal);
                     Assert.NotNull(servicePrincipal.ApplicationId);
                     Assert.Equal(2, servicePrincipal.ServicePrincipalNames.Count);
                     Assert.Equal(0, servicePrincipal.PasswordCredentials.Count);
-                    Assert.Equal(1, servicePrincipal.CertificateCredentials.Count);
+                    Assert.Equal(2, servicePrincipal.CertificateCredentials.Count);
                 }
                 finally
                 {

--- a/Tests/Fluent.Tests/SessionRecords/Fluent.Tests.Graph.RBAC.Applications/CanCRUDApplication.json
+++ b/Tests/Fluent.Tests/SessionRecords/Fluent.Tests.Graph.RBAC.Applications/CanCRUDApplication.json
@@ -4,30 +4,30 @@
       "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications?api-version=1.6",
       "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnM/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"availableToOtherTenants\": false,\r\n  \"displayName\": \"javasdkappdc0573821\",\r\n  \"homepage\": \"http://easycreate.azure.com/javasdkappdc0573821\",\r\n  \"identifierUris\": [\r\n    \"http://easycreate.azure.com/javasdkappdc0573821\"\r\n  ],\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/javasdkappdc0573821\"\r\n  ],\r\n  \"keyCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"startDate\": \"2018-01-10T07:13:26.3974012Z\",\r\n      \"endDate\": \"2018-04-20T07:13:26.3974012Z\",\r\n      \"value\": \"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDd1RDQ0FhbWdBd0lCQWdJRUprNTJ1REFOQmdrcWhraUc5dzBCQVFzRkFEQVJNUTh3RFFZRFZRUURFd1p0DQplVlJsYzNRd0hoY05NVFl4TVRFeU1ERXhNekkyV2hjTk1qWXhNVEV3TURFeE16STJXakFSTVE4d0RRWURWUVFEDQpFd1p0ZVZSbGMzUXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDYm56SkYzYysvDQpzY2JnUnluc2l4eG1XbDNHZFppUUh2b0FjVWJXZUdkbDF1bzBSVDZYeThCQ0tkWENCUW9ZbXhuZzNYYnZTS2RiDQp2UGUyYmtHVDlBMDhxVTh5VXFUMGJFSXFXNUZCZ3g1ZEVzdzRUeCtuOXA3UWhKTWF3Nlg1NFZ1SlVieVVwNERaDQp2VGxlOTluMDBqR0hwdDZUQndqb0VJNnNET1M3WG5lblk5WVIxR1hEY00zcVdidklXVHJ6SmFxeXMxUmdTYnhnDQpjUklMbjg4NVZaWkx1dXlqVTZXaEpRRmZ4L2kzR1hLVDNaUDhyVTNlNmQ3cTBQalZBS3lGd2FNTlZlVTRWbURpDQo3a25HaHlDODRJWW8xT0ZLc0FjU1ZDYXhkU1FiT0dhZXh2RmFqMmpqb0tmdlkzZG40aW9vM3lJelNNSmdsZk1BDQpISFgveHpUa3gyN2xBZ01CQUFHaklUQWZNQjBHQTFVZERnUVdCQlNDUXVicXhkSVBVdS9QRVdxUmxTWHBLTEZ1DQpxVEFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQ3A2WUNLdDhGamtQdW5sQ0lKUFZZeFJZUTNzdDdHL0pGMnk5DQowRWlQWlc4THNCOFFTL0dQcmNoQmFaZE9pMVNNTGtEdlMyQnozN3VuSks3WUY2WC9JWG1nYWNDSkpjTnlXci8wDQpJdURUNGYwaHUzVCtYeWZlMFRVeFZJQzRDYjhpY3c1SXBGMkVhZ1ZhY0VSVFpHQi91MzhZNzdGYTNKUlN4NHdaDQpuc0hUbVA0SlNLdU94UlprbkR3NS9nSEdIZkhyKzlueWNOSjdJSHJZS0tDRUVna2hEVXZVYXgzZk4zVFd5WmFwDQpSOThTK1JRYUozckxhTmlOcVZqdUdyYkhqUmVRaWtUdFp3Q3RscE04Vkhvdml5eVRVRTd4a2VrTTJwNFloRHBEDQpaRE4raTJPZ1VLc1NLbUR3clpUQzczMkQwRzdyODBmbDk2ZXpOTTlPN3FoNDU3aWhWQT09DQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tDQo=\",\r\n      \"usage\": \"Verify\",\r\n      \"type\": \"AsymmetricX509Cert\"\r\n    }\r\n  ],\r\n  \"passwordCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"cGFzc3dk\",\r\n      \"startDate\": \"2018-01-10T07:13:26.3974012Z\",\r\n      \"endDate\": \"2018-04-20T07:13:26.3974012Z\",\r\n      \"value\": \"P@ssw0rd\"\r\n    }\r\n  ]\r\n}",
+      "RequestBody": "{\r\n  \"availableToOtherTenants\": false,\r\n  \"displayName\": \"javasdkappfd693668d\",\r\n  \"homepage\": \"http://easycreate.azure.com/javasdkappfd693668d\",\r\n  \"identifierUris\": [\r\n    \"http://easycreate.azure.com/javasdkappfd693668d\"\r\n  ],\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/javasdkappfd693668d\"\r\n  ],\r\n  \"keyCredentials\": [\r\n    {\r\n      \"startDate\": \"2018-06-27T18:30:57.701736Z\",\r\n      \"endDate\": \"2018-10-05T18:30:57.701736Z\",\r\n      \"value\": \"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDd1RDQ0FhbWdBd0lCQWdJRUprNTJ1REFOQmdrcWhraUc5dzBCQVFzRkFEQVJNUTh3RFFZRFZRUURFd1p0DQplVlJsYzNRd0hoY05NVFl4TVRFeU1ERXhNekkyV2hjTk1qWXhNVEV3TURFeE16STJXakFSTVE4d0RRWURWUVFEDQpFd1p0ZVZSbGMzUXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDYm56SkYzYysvDQpzY2JnUnluc2l4eG1XbDNHZFppUUh2b0FjVWJXZUdkbDF1bzBSVDZYeThCQ0tkWENCUW9ZbXhuZzNYYnZTS2RiDQp2UGUyYmtHVDlBMDhxVTh5VXFUMGJFSXFXNUZCZ3g1ZEVzdzRUeCtuOXA3UWhKTWF3Nlg1NFZ1SlVieVVwNERaDQp2VGxlOTluMDBqR0hwdDZUQndqb0VJNnNET1M3WG5lblk5WVIxR1hEY00zcVdidklXVHJ6SmFxeXMxUmdTYnhnDQpjUklMbjg4NVZaWkx1dXlqVTZXaEpRRmZ4L2kzR1hLVDNaUDhyVTNlNmQ3cTBQalZBS3lGd2FNTlZlVTRWbURpDQo3a25HaHlDODRJWW8xT0ZLc0FjU1ZDYXhkU1FiT0dhZXh2RmFqMmpqb0tmdlkzZG40aW9vM3lJelNNSmdsZk1BDQpISFgveHpUa3gyN2xBZ01CQUFHaklUQWZNQjBHQTFVZERnUVdCQlNDUXVicXhkSVBVdS9QRVdxUmxTWHBLTEZ1DQpxVEFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQ3A2WUNLdDhGamtQdW5sQ0lKUFZZeFJZUTNzdDdHL0pGMnk5DQowRWlQWlc4THNCOFFTL0dQcmNoQmFaZE9pMVNNTGtEdlMyQnozN3VuSks3WUY2WC9JWG1nYWNDSkpjTnlXci8wDQpJdURUNGYwaHUzVCtYeWZlMFRVeFZJQzRDYjhpY3c1SXBGMkVhZ1ZhY0VSVFpHQi91MzhZNzdGYTNKUlN4NHdaDQpuc0hUbVA0SlNLdU94UlprbkR3NS9nSEdIZkhyKzlueWNOSjdJSHJZS0tDRUVna2hEVXZVYXgzZk4zVFd5WmFwDQpSOThTK1JRYUozckxhTmlOcVZqdUdyYkhqUmVRaWtUdFp3Q3RscE04Vkhvdml5eVRVRTd4a2VrTTJwNFloRHBEDQpaRE4raTJPZ1VLc1NLbUR3clpUQzczMkQwRzdyODBmbDk2ZXpOTTlPN3FoNDU3aWhWQT09DQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tDQo=\",\r\n      \"usage\": \"Verify\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"customKeyIdentifier\": \"Y2VydA==\"\r\n    },\r\n    {\r\n      \"startDate\": \"2018-06-27T18:30:57.7177357Z\",\r\n      \"endDate\": \"2018-09-15T18:30:57.7177357Z\",\r\n      \"value\": \"MIICwzCCAaugAwIBAgIEAeU3rDANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDEwdteUNlcnQyMB4XDTE2MTExMzE4NDkyOVoXDTI2MTExMTE4NDkyOVowEjEQMA4GA1UEAxMHbXlDZXJ0MjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKoFamQIOH3rawbj8cClxT5t7qfOlnJC7zOApTUOvIPYvRq7jA/Q0SqSKgNSNYhdQDN4qFwbLDDYI2GKu/Woc41IjPq22G65CHT065yfm71I0EkBPqMylX7O3ROvcUqL5qhIsYRq8vHxRDkakFtF8XDCnBt5h5O5Z7M71Vrk/y+qQXhW3Mv0iCYGWgR6RXAXB9akVOYMRpFRl9JtRr3eqauw/Y2H+7qN0KO+NhHD466blyV2n7GbV4WAs/3Ef4Hn2YWFNqBWaHGAiB/J7JkzoXIiJLdibnbbsySsUPqJLEjgSKoGUMW5Hv3RqOypohk//+ZM1tQ5NqzjtzDvgzMYkocCAwEAAaMhMB8wHQYDVR0OBBYEFBGBkNRKdeYcVPKuwncc1IG3gpFhMA0GCSqGSIb3DQEBCwUAA4IBAQBSMDWvfs380j2A7pF9B902g6ii3NTypzqBoGu1hHjiannyP+dWmwUU7WSWkQomCILST2Y0Kc76icHz8D5SmLH1ITnwO3F3urJ7eXTybh1acYgjZUE61D1l9dCtLIsWOypQ0OvlOiJy3Mrq6S1p6RtCC2Ysol7jR5fxc7TwCexO4jL6qqCAKnTc90rukWzScEExwTzZOmN5zXwbRHTdos2wo832A8Twb20oyuXqLDiWupC3AQK/2sE3PbJZCsaPbsq09DYLyU44NQsdQq2uyzE3vCmZZorUHEO/NQR9bF06rqa3k0aI7as1naKM/m6RAhKfTuLITBSV2s4rWUInRToS\",\r\n      \"usage\": \"Verify\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"customKeyIdentifier\": \"Y2VydA==\"\r\n    }\r\n  ],\r\n  \"passwordCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"cGFzc3dk\",\r\n      \"startDate\": \"2018-06-27T18:30:57.6887369Z\",\r\n      \"endDate\": \"2018-10-05T18:30:57.6887369Z\",\r\n      \"value\": \"P@ssw0rd\"\r\n    }\r\n  ]\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "2178"
+          "3365"
         ],
         "x-ms-client-request-id": [
-          "fc3f858a-c160-4240-8dc6-300d7b96eda2"
+          "1f610a00-6011-45e5-9dbe-0a239d754f50"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.Application\",\r\n  \"objectType\": \"Application\",\r\n  \"objectId\": \"bd55abfd-e9c2-47ce-9c10-5c2259a0843b\",\r\n  \"deletionTimestamp\": null,\r\n  \"acceptMappedClaims\": null,\r\n  \"addIns\": [],\r\n  \"appId\": \"2f153fca-dd3e-499e-8ef6-8508020c1af2\",\r\n  \"appRoles\": [],\r\n  \"availableToOtherTenants\": false,\r\n  \"displayName\": \"javasdkappdc0573821\",\r\n  \"errorUrl\": null,\r\n  \"groupMembershipClaims\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/javasdkappdc0573821\",\r\n  \"identifierUris\": [\r\n    \"http://easycreate.azure.com/javasdkappdc0573821\"\r\n  ],\r\n  \"informationalUrls\": {\r\n    \"termsOfService\": null,\r\n    \"support\": null,\r\n    \"privacy\": null,\r\n    \"marketing\": null\r\n  },\r\n  \"keyCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-04-20T07:13:26.3974012Z\",\r\n      \"keyId\": \"cf0e8243-a3b0-497a-81be-f2688a4786e8\",\r\n      \"startDate\": \"2018-01-10T07:13:26.3974012Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ],\r\n  \"knownClientApplications\": [],\r\n  \"logoutUrl\": null,\r\n  \"oauth2AllowImplicitFlow\": false,\r\n  \"oauth2AllowUrlPathMatching\": false,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access javasdkappdc0573821 on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access javasdkappdc0573821\",\r\n      \"id\": \"a418d52b-f279-4015-bceb-b1144bfdb07b\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access javasdkappdc0573821 on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access javasdkappdc0573821\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"oauth2RequirePostResponse\": false,\r\n  \"optionalClaims\": null,\r\n  \"passwordCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"cGFzc3dk\",\r\n      \"endDate\": \"2018-04-20T07:13:26.3974012Z\",\r\n      \"keyId\": \"e649f27b-509a-47c1-94db-3093e271890d\",\r\n      \"startDate\": \"2018-01-10T07:13:26.3974012Z\",\r\n      \"value\": null\r\n    }\r\n  ],\r\n  \"publicClient\": null,\r\n  \"recordConsentConditions\": null,\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/javasdkappdc0573821\"\r\n  ],\r\n  \"requiredResourceAccess\": [],\r\n  \"samlMetadataUrl\": null,\r\n  \"tokenEncryptionKeyId\": null,\r\n  \"isDeviceOnlyAuthSupported\": null\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.Application\",\r\n  \"objectType\": \"Application\",\r\n  \"objectId\": \"b2bdde58-0bc8-4cf7-bd22-6c8ed3dafd83\",\r\n  \"deletionTimestamp\": null,\r\n  \"acceptMappedClaims\": null,\r\n  \"addIns\": [],\r\n  \"appId\": \"b2bebe39-6894-4852-8210-487d5787b413\",\r\n  \"appRoles\": [],\r\n  \"availableToOtherTenants\": false,\r\n  \"displayName\": \"javasdkappfd693668d\",\r\n  \"errorUrl\": null,\r\n  \"groupMembershipClaims\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/javasdkappfd693668d\",\r\n  \"identifierUris\": [\r\n    \"http://easycreate.azure.com/javasdkappfd693668d\"\r\n  ],\r\n  \"informationalUrls\": {\r\n    \"termsOfService\": null,\r\n    \"support\": null,\r\n    \"privacy\": null,\r\n    \"marketing\": null\r\n  },\r\n  \"isDeviceOnlyAuthSupported\": null,\r\n  \"keyCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-09-15T18:30:57.7177357Z\",\r\n      \"keyId\": \"6e1131b2-3424-4b2c-ae41-0b8ade3c8408\",\r\n      \"startDate\": \"2018-06-27T18:30:57.7177357Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    },\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-10-05T18:30:57.701736Z\",\r\n      \"keyId\": \"c71f7dd1-e6b2-4203-a9cf-4dac09b1eb87\",\r\n      \"startDate\": \"2018-06-27T18:30:57.701736Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ],\r\n  \"knownClientApplications\": [],\r\n  \"logoutUrl\": null,\r\n  \"logo@odata.mediaContentType\": \"application/json;odata=minimalmetadata; charset=utf-8\",\r\n  \"logoUrl\": null,\r\n  \"oauth2AllowIdTokenImplicitFlow\": true,\r\n  \"oauth2AllowImplicitFlow\": false,\r\n  \"oauth2AllowUrlPathMatching\": false,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access javasdkappfd693668d on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access javasdkappfd693668d\",\r\n      \"id\": \"99932b60-298b-4873-934e-56897c22e1d9\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access javasdkappfd693668d on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access javasdkappfd693668d\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"oauth2RequirePostResponse\": false,\r\n  \"optionalClaims\": null,\r\n  \"orgRestrictions\": [],\r\n  \"parentalControlSettings\": {\r\n    \"countriesBlockedForMinors\": [],\r\n    \"legalAgeGroupRule\": \"Allow\"\r\n  },\r\n  \"passwordCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"cGFzc3dk\",\r\n      \"endDate\": \"2018-10-05T18:30:57.6887369Z\",\r\n      \"keyId\": \"a83963f0-7e6b-4e54-8a5d-82aec5645225\",\r\n      \"startDate\": \"2018-06-27T18:30:57.6887369Z\",\r\n      \"value\": null\r\n    }\r\n  ],\r\n  \"publicClient\": null,\r\n  \"publisherDomain\": null,\r\n  \"recordConsentConditions\": null,\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/javasdkappfd693668d\"\r\n  ],\r\n  \"requiredResourceAccess\": [],\r\n  \"samlMetadataUrl\": null,\r\n  \"signInAudience\": \"AzureADMyOrg\",\r\n  \"tokenEncryptionKeyId\": null\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "2036"
+          "2560"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -39,31 +39,31 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 07:13:26 GMT"
+          "Wed, 27 Jun 2018 18:30:58 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/bd55abfd-e9c2-47ce-9c10-5c2259a0843b/Microsoft.DirectoryServices.Application"
+          "https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/b2bdde58-0bc8-4cf7-bd22-6c8ed3dafd83/Microsoft.DirectoryServices.Application"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "Di2Mb1FQpAkptjcd3t0sJrUHBU1H5BG1v34ttQWjQvo="
+          "2Gv1gQSfiKJpA3rt4Mi13yQYs8l/cSGK1elzeDUE/p8="
         ],
         "request-id": [
-          "b74b7c86-bb0f-486e-af38-492d251c5536"
+          "3b90a2a2-b0f1-4bea-9f85-e62aaa057722"
         ],
         "client-request-id": [
-          "e8cb1f0c-5232-4dde-8c43-e2f532710a79"
+          "1074c6f6-ee94-452f-a0cf-da9854149443"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "e81nkwSQ-w8H_Cvvd5ShXDOkgAvnFDdzoDhlxRTr8Mo5UXwPLi9c1jmzB9n6gR_lsTVIpY5RKd6izGkj4alKaUSRWdZeqi9yiz3G1d6hm0qa5ZM6Wru_bDf_BmFHU4K4u6Dyx41pgPNJmmJNNwgC_XfxRpXX_-CAa9DDDGHUNeq6iTRsYFjVZJT7FuINOy3bfQ_mnSv-GjTuBdGKqOUXrA.g8rDYsze_9P8bpKdWyst34RMlrscMmY0CcvJ8uZGa9I"
+          "tAwMypEgz60EbIVuQWDL_-Q7kyoAgFPR8kP7a81uVbQRr8ZsWgj7LwoM2MjgZfmesGzdp2h7IGNgzJJSrIk645oejnkUFtV_BAm0T689nQ4HE8844Uafy8Ey6Pd3DDmR1VUBCCw6Uj15iUQKWjprng.fhVTSIPyrIRugUdIAObOUdudAOSuvH2s_6I5JMuZTbg"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -85,33 +85,33 @@
           "ASP.NET"
         ],
         "Duration": [
-          "5642357"
+          "3399504"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bd55abfd-e9c2-47ce-9c10-5c2259a0843b/keyCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmQ1NWFiZmQtZTljMi00N2NlLTljMTAtNWMyMjU5YTA4NDNiL2tleUNyZWRlbnRpYWxzP2FwaS12ZXJzaW9uPTEuNg==",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/b2bdde58-0bc8-4cf7-bd22-6c8ed3dafd83/keyCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYjJiZGRlNTgtMGJjOC00Y2Y3LWJkMjItNmM4ZWQzZGFmZDgzL2tleUNyZWRlbnRpYWxzP2FwaS12ZXJzaW9uPTEuNg==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "cf1b04cf-eb53-43f9-922c-e5bcc6b5f4d8"
+          "4b868950-c7ab-46c0-a834-1ad22b12bb58"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-04-20T07:13:26.3974012Z\",\r\n      \"keyId\": \"cf0e8243-a3b0-497a-81be-f2688a4786e8\",\r\n      \"startDate\": \"2018-01-10T07:13:26.3974012Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-09-15T18:30:57.7177357Z\",\r\n      \"keyId\": \"6e1131b2-3424-4b2c-ae41-0b8ade3c8408\",\r\n      \"startDate\": \"2018-06-27T18:30:57.7177357Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    },\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-10-05T18:30:57.701736Z\",\r\n      \"keyId\": \"c71f7dd1-e6b2-4203-a9cf-4dac09b1eb87\",\r\n      \"startDate\": \"2018-06-27T18:30:57.701736Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "381"
+          "603"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -123,28 +123,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 07:13:27 GMT"
+          "Wed, 27 Jun 2018 18:30:58 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "xIuw/bjp1m+FmuGFABwVtmA1fSSJJ+nF3+G3Tmx0epc="
+          "N0M3YZBHM6R48FUQoMpphT0YYue9AYIC839ozsEY+h0="
         ],
         "request-id": [
-          "05b2382a-a383-40b2-9028-d85ea3f0716a"
+          "59e3e9eb-9bc2-441e-9a72-d95a08288996"
         ],
         "client-request-id": [
-          "65e18903-db0b-4277-86c6-2c058f91588e"
+          "9758d87b-085e-44ab-bf7b-772254e0fa63"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "gEKzm7VB3KkovgwuNaLXERU_Hu7-yzJ2MpZCgw6GJDaOYhMN_W1a4OXLX_OQ6lDw8ZVCzBDqW2usqOevwQq8vUcb-Dmd8tGcZ7yD6PyE0zwDH85IjKTjZWB2SLioyije3AzzGO7WdBw71Q3wQmUj1s6FrNchSoFIR9MYniw1c6V67teT3hkYrNSMUr3QjqDRUs3CEpfgc5OjbGTncAeB-Q.W6zDTg0E-ox77YFVBImoMG0h3q3F1Mgze10aP5D_AjU"
+          "0qfhuFS2YoKnJqaQBiESl0i-lGXQbA4Szc3qai9zQu8sCKgj_diPPt-ytz5oA0aj_osxV9NcCHGwxQGbPoyQXxqkISJIOAK3cWN_7971luBtPb-om3TNK5IhZloiDKPgWAAV1dnsbH2z15FxR7Z30g.vhLnKWM69ElVHO4M2oMxfBjSWA0iM6BvmeOChEsu1EM"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -166,33 +166,33 @@
           "ASP.NET"
         ],
         "Duration": [
-          "683245"
+          "1259914"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bd55abfd-e9c2-47ce-9c10-5c2259a0843b/keyCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmQ1NWFiZmQtZTljMi00N2NlLTljMTAtNWMyMjU5YTA4NDNiL2tleUNyZWRlbnRpYWxzP2FwaS12ZXJzaW9uPTEuNg==",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/b2bdde58-0bc8-4cf7-bd22-6c8ed3dafd83/keyCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYjJiZGRlNTgtMGJjOC00Y2Y3LWJkMjItNmM4ZWQzZGFmZDgzL2tleUNyZWRlbnRpYWxzP2FwaS12ZXJzaW9uPTEuNg==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "a4186393-2af4-4ac8-9ada-68baa433c09e"
+          "7aa1ee4b-b56d-4718-b364-aaae93457b21"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-04-20T07:13:26.3974012Z\",\r\n      \"keyId\": \"cf0e8243-a3b0-497a-81be-f2688a4786e8\",\r\n      \"startDate\": \"2018-01-10T07:13:26.3974012Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-09-15T18:30:57.7177357Z\",\r\n      \"keyId\": \"6e1131b2-3424-4b2c-ae41-0b8ade3c8408\",\r\n      \"startDate\": \"2018-06-27T18:30:57.7177357Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    },\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-10-05T18:30:57.701736Z\",\r\n      \"keyId\": \"c71f7dd1-e6b2-4203-a9cf-4dac09b1eb87\",\r\n      \"startDate\": \"2018-06-27T18:30:57.701736Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "381"
+          "603"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -204,28 +204,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 07:13:27 GMT"
+          "Wed, 27 Jun 2018 18:30:59 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "IMwhZ7re0vXZKhEwYqVrwiyjRVhRmebmFUlFEPOwZ+o="
+          "MMNpM+Iz2yBvvf+Oc4D7IA0nZD5jNPjSkaGpHqkyRbc="
         ],
         "request-id": [
-          "5a1361ed-261f-49e7-b65b-368dde19eab1"
+          "e34162cf-b2dd-4f44-8fc7-7ae01c5d2a45"
         ],
         "client-request-id": [
-          "be3b2861-12f8-4dd1-8743-1960112f2240"
+          "d3997632-509c-4759-bea7-91319644ae46"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "x2LpKuOgU5TEjvZejqTtbNaTZVcNXL-AvKJ4rkFSN57cHmn6U1e4S4Dt82Wtmo2kbkvl0Y6dYFme8tsphQjejflPqmYTGaH4wOlrQe3XEYN0jo-Em1-OQuAFbuECKtXKIl4YzUyKC2c5K8S9QwNmTFzbQ1BEd0qwOSd8zec8wocAiJgFpFUucaJG6Edp6wfQXYBBQxZU4g137tzJwzzyHQ.YRmttecvJXIWcI2DszmwsqWfNZxe_pPmQHYo9JQ_P04"
+          "1qIj129klLXw8zVH0P6UeCn9v9YScmQiFEnt0KWUqEE9Ll808yPXu6G_FVT1AMzt-d-ihgmNIs0PrJmH3EIMY9UBoviwvpmezZCzY_ePbNu0rgeoVx3fEfkdh2u2cQVZ3c7lU_VvIPjxVnX9G_uQeg._FOpSLoRC9jRnlSehchRjBQ3xf6-aaz2wtWoRQHZnB0"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -247,30 +247,30 @@
           "ASP.NET"
         ],
         "Duration": [
-          "906118"
+          "647594"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bd55abfd-e9c2-47ce-9c10-5c2259a0843b/passwordCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmQ1NWFiZmQtZTljMi00N2NlLTljMTAtNWMyMjU5YTA4NDNiL3Bhc3N3b3JkQ3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/b2bdde58-0bc8-4cf7-bd22-6c8ed3dafd83/passwordCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYjJiZGRlNTgtMGJjOC00Y2Y3LWJkMjItNmM4ZWQzZGFmZDgzL3Bhc3N3b3JkQ3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "32d1504a-ae87-493f-a3d4-013c77987775"
+          "2d97a4bd-c791-4855-a1f5-6670a92128f4"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"cGFzc3dk\",\r\n      \"endDate\": \"2018-04-20T07:13:26.3974012Z\",\r\n      \"keyId\": \"e649f27b-509a-47c1-94db-3093e271890d\",\r\n      \"startDate\": \"2018-01-10T07:13:26.3974012Z\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"cGFzc3dk\",\r\n      \"endDate\": \"2018-10-05T18:30:57.6887369Z\",\r\n      \"keyId\": \"a83963f0-7e6b-4e54-8a5d-82aec5645225\",\r\n      \"startDate\": \"2018-06-27T18:30:57.6887369Z\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "341"
@@ -285,28 +285,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 07:13:27 GMT"
+          "Wed, 27 Jun 2018 18:30:58 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "IMwhZ7re0vXZKhEwYqVrwiyjRVhRmebmFUlFEPOwZ+o="
+          "R24SEsKL6l8WwGja0LsRtb5gfSEzPaANsccbqgL6qjQ="
         ],
         "request-id": [
-          "7264add0-bf7b-4535-b69f-ef39f9892dfc"
+          "3f66dba9-05a2-4b33-b546-cb1cc1ce16f5"
         ],
         "client-request-id": [
-          "cae3d52c-cd7f-4f36-9b6e-5c4fa4d17272"
+          "44f3f0b1-9823-4468-bb6c-ccd02da3f814"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "qYJrllUu0Ad9CyfHgUCHZN9B_yvOxcBDT5sjkGAGguGkHzsOVSi4jYbD0QYWAvlZp-ThHsCt8N7MxEFbxDfB8QI035GI5QkAl5ClLJ8B5ahlfjpr8EH_0nUNQfjnbY7t2156CW2tcd3vaPLa-Z48WwFXz2uecqLyVzm_6x7CMWrZRfCDBKf9TDuQv4-frNGk6-5alf_IbG1wkq_v67FEUg.iHlHzXi_Ij5usjb3ItJMSQh3_EV7QcpYbUYFe1yCh6U"
+          "q8dqY9KGnbD_dXSFVRvECgYpshe7cPnBaVTSO_H17SeagV_1xrlOElQPhLn9WL-WNliWYdVssdLTFRuz5T6aIrJO6P-UrFyjWPzk77aFHgs0KBfQSu_0VDjFvxyPDILXBknKywI1NndulPaSzbGD3A.0qmvWXJZyZctAJkWL1Q5O0YmmEcliuHRvmC4W8NMllY"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -328,27 +328,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "688876"
+          "805287"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bd55abfd-e9c2-47ce-9c10-5c2259a0843b/passwordCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmQ1NWFiZmQtZTljMi00N2NlLTljMTAtNWMyMjU5YTA4NDNiL3Bhc3N3b3JkQ3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/b2bdde58-0bc8-4cf7-bd22-6c8ed3dafd83/passwordCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYjJiZGRlNTgtMGJjOC00Y2Y3LWJkMjItNmM4ZWQzZGFmZDgzL3Bhc3N3b3JkQ3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "53759200-fe3b-4a24-becc-0bbb3d6b6e6c"
+          "afde94b9-0ef9-465f-9804-9761d1c5d044"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": []\r\n}",
@@ -366,28 +366,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 07:13:27 GMT"
+          "Wed, 27 Jun 2018 18:30:59 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "IMwhZ7re0vXZKhEwYqVrwiyjRVhRmebmFUlFEPOwZ+o="
+          "R24SEsKL6l8WwGja0LsRtb5gfSEzPaANsccbqgL6qjQ="
         ],
         "request-id": [
-          "1c49599d-2698-465f-a90c-91481dd247d3"
+          "45118e49-ef49-484f-b895-e5f2a64a96d0"
         ],
         "client-request-id": [
-          "4c50794c-b5b6-4fd6-b65b-f8bfe560e9fd"
+          "a42eb0eb-9db9-4165-9f2c-d4f4351a7f5c"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "tSjmK1KKPW_6Y3Uu1PTgSkiqZL6LiiCV9RTEL9yHqPswBFBowdxGbcomGw8Z_mZE830FHqX0EdEhYNJajQVndboO8pJipBuUrsEFfRzYH97B20o3NyMT0mS8ePBJRjHqwVUXTSHkNl1sO-l5do6vlxE5vPzCXMNtlWOaBnEB_3kAmEpMFY7eAN6ZEwuf2h4HdHBsyFt5M93Bb8gX72WGIA.3OeI-hI8reoQmr3fQpsKa4KV6r72mZZ8QMKjEPM_CrQ"
+          "AwC99LZ7N6nnjgq5fGXS0WVEBqwRpqKjLyQn-cRBKzSOkBoFXOvD5BDaj9h5DEsT4PLEnurEGI88Kr21_jFYKfq5lMP2xS_uuEv4ACC4B1ZYsB6WBDBekZlGalVXd34vn6GcZa2AYZ2MBrNge7cGqw.b38O8FYsRoqpus9XGeqy2XmVhkmNngwmBk8EGjIMszQ"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -409,16 +409,16 @@
           "ASP.NET"
         ],
         "Duration": [
-          "1988598"
+          "457670"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bd55abfd-e9c2-47ce-9c10-5c2259a0843b?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmQ1NWFiZmQtZTljMi00N2NlLTljMTAtNWMyMjU5YTA4NDNiP2FwaS12ZXJzaW9uPTEuNg==",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/b2bdde58-0bc8-4cf7-bd22-6c8ed3dafd83?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYjJiZGRlNTgtMGJjOC00Y2Y3LWJkMjItNmM4ZWQzZGFmZDgzP2FwaS12ZXJzaW9uPTEuNg==",
       "RequestMethod": "PATCH",
-      "RequestBody": "{\r\n  \"displayName\": \"javasdkappdc0573821\",\r\n  \"passwordCredentials\": []\r\n}",
+      "RequestBody": "{\r\n  \"displayName\": \"javasdkappfd693668d\",\r\n  \"passwordCredentials\": []\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -427,15 +427,15 @@
           "74"
         ],
         "x-ms-client-request-id": [
-          "32e669be-5bc8-49d4-b5d5-c6ea08a73a7a"
+          "3bab5d15-6353-4307-b2fc-532cf1725531"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "",
@@ -447,28 +447,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 07:13:27 GMT"
+          "Wed, 27 Jun 2018 18:30:59 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "UUsoRVZx52dAfTb5wv/hhWzDqbmsJKcNRViHoL4/1IY="
+          "d1JB6ucVep7/SQwUJWs6eqivZfWvC07ij1sG/PhNZn0="
         ],
         "request-id": [
-          "679dae16-e0c9-4313-9474-1d7912f7fc65"
+          "5d07728e-2bc9-4136-802b-4373c3468e22"
         ],
         "client-request-id": [
-          "5db5d460-e492-4513-9cb8-08f7be035511"
+          "9b0d38c6-d06f-4cc1-b1bd-b4a7c9a9d0f0"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "hThBZ97fFGE8FCW975_eE8Oqg-t-t9TB6Ud2iqiOXCcMrcgzI1Fo3tywap2EFLJ30-SvWrAAelcMBvVX4YmAz5yhQSuJseVTrzX6rb9TKnRsWu0mK9eZYzePwQSuzrpzxlZ3C8LaLFYWwCyGoNfxQbKvvqWjb0XRBVQqg9vWq_skuy8ouL1kGvAh96u0vG_ubcD_nre2F2zVPgZsQ5g6ZQ.kEpmTLFNxK_HdhMC_4ITbvFiv6AMvDFUdIA43UtpXMU"
+          "NuRmLA1bvdMZJXtGKvuH7FZJrfsNXYJphF7K36Nf5c0IplPTCQsOfHp971ESL0dCgLV7vYXTzfwoEYMJgbPohcsQIiRnpu_l6ANdi8NtpFLvAbSi9JNzPcygR2c7mSp1Q-KOiFCh7ueSNlX7wpdsbA.yJfsMo8URr5Wr42WwyGMDRNdIqnxcwEIM5fvnVeaY4Y"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -490,33 +490,33 @@
           "ASP.NET"
         ],
         "Duration": [
-          "1957493"
+          "1977854"
         ]
       },
       "StatusCode": 204
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bd55abfd-e9c2-47ce-9c10-5c2259a0843b?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmQ1NWFiZmQtZTljMi00N2NlLTljMTAtNWMyMjU5YTA4NDNiP2FwaS12ZXJzaW9uPTEuNg==",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/b2bdde58-0bc8-4cf7-bd22-6c8ed3dafd83?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYjJiZGRlNTgtMGJjOC00Y2Y3LWJkMjItNmM4ZWQzZGFmZDgzP2FwaS12ZXJzaW9uPTEuNg==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "193c416a-d189-4c5d-9c5d-cad828a0482c"
+          "6cff94e7-9548-4b74-a1e0-411769b051d5"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.Application\",\r\n  \"objectType\": \"Application\",\r\n  \"objectId\": \"bd55abfd-e9c2-47ce-9c10-5c2259a0843b\",\r\n  \"deletionTimestamp\": null,\r\n  \"acceptMappedClaims\": null,\r\n  \"addIns\": [],\r\n  \"appId\": \"2f153fca-dd3e-499e-8ef6-8508020c1af2\",\r\n  \"appRoles\": [],\r\n  \"availableToOtherTenants\": false,\r\n  \"displayName\": \"javasdkappdc0573821\",\r\n  \"errorUrl\": null,\r\n  \"groupMembershipClaims\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/javasdkappdc0573821\",\r\n  \"identifierUris\": [\r\n    \"http://easycreate.azure.com/javasdkappdc0573821\"\r\n  ],\r\n  \"informationalUrls\": {\r\n    \"termsOfService\": null,\r\n    \"support\": null,\r\n    \"privacy\": null,\r\n    \"marketing\": null\r\n  },\r\n  \"keyCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-04-20T07:13:26.3974012Z\",\r\n      \"keyId\": \"cf0e8243-a3b0-497a-81be-f2688a4786e8\",\r\n      \"startDate\": \"2018-01-10T07:13:26.3974012Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ],\r\n  \"knownClientApplications\": [],\r\n  \"logoutUrl\": null,\r\n  \"oauth2AllowImplicitFlow\": false,\r\n  \"oauth2AllowUrlPathMatching\": false,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access javasdkappdc0573821 on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access javasdkappdc0573821\",\r\n      \"id\": \"a418d52b-f279-4015-bceb-b1144bfdb07b\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access javasdkappdc0573821 on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access javasdkappdc0573821\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"oauth2RequirePostResponse\": false,\r\n  \"optionalClaims\": null,\r\n  \"passwordCredentials\": [],\r\n  \"publicClient\": null,\r\n  \"recordConsentConditions\": null,\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/javasdkappdc0573821\"\r\n  ],\r\n  \"requiredResourceAccess\": [],\r\n  \"samlMetadataUrl\": null,\r\n  \"tokenEncryptionKeyId\": null,\r\n  \"isDeviceOnlyAuthSupported\": null\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.Application\",\r\n  \"objectType\": \"Application\",\r\n  \"objectId\": \"b2bdde58-0bc8-4cf7-bd22-6c8ed3dafd83\",\r\n  \"deletionTimestamp\": null,\r\n  \"acceptMappedClaims\": null,\r\n  \"addIns\": [],\r\n  \"appId\": \"b2bebe39-6894-4852-8210-487d5787b413\",\r\n  \"appRoles\": [],\r\n  \"availableToOtherTenants\": false,\r\n  \"displayName\": \"javasdkappfd693668d\",\r\n  \"errorUrl\": null,\r\n  \"groupMembershipClaims\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/javasdkappfd693668d\",\r\n  \"identifierUris\": [\r\n    \"http://easycreate.azure.com/javasdkappfd693668d\"\r\n  ],\r\n  \"informationalUrls\": {\r\n    \"termsOfService\": null,\r\n    \"support\": null,\r\n    \"privacy\": null,\r\n    \"marketing\": null\r\n  },\r\n  \"isDeviceOnlyAuthSupported\": null,\r\n  \"keyCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-09-15T18:30:57.7177357Z\",\r\n      \"keyId\": \"6e1131b2-3424-4b2c-ae41-0b8ade3c8408\",\r\n      \"startDate\": \"2018-06-27T18:30:57.7177357Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    },\r\n    {\r\n      \"customKeyIdentifier\": \"Y2VydA==\",\r\n      \"endDate\": \"2018-10-05T18:30:57.701736Z\",\r\n      \"keyId\": \"c71f7dd1-e6b2-4203-a9cf-4dac09b1eb87\",\r\n      \"startDate\": \"2018-06-27T18:30:57.701736Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ],\r\n  \"knownClientApplications\": [],\r\n  \"logoutUrl\": null,\r\n  \"logoUrl\": null,\r\n  \"oauth2AllowIdTokenImplicitFlow\": true,\r\n  \"oauth2AllowImplicitFlow\": false,\r\n  \"oauth2AllowUrlPathMatching\": false,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access javasdkappfd693668d on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access javasdkappfd693668d\",\r\n      \"id\": \"99932b60-298b-4873-934e-56897c22e1d9\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access javasdkappfd693668d on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access javasdkappfd693668d\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"oauth2RequirePostResponse\": false,\r\n  \"optionalClaims\": null,\r\n  \"orgRestrictions\": [],\r\n  \"parentalControlSettings\": {\r\n    \"countriesBlockedForMinors\": [],\r\n    \"legalAgeGroupRule\": \"Allow\"\r\n  },\r\n  \"passwordCredentials\": [],\r\n  \"publicClient\": null,\r\n  \"publisherDomain\": null,\r\n  \"recordConsentConditions\": null,\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/javasdkappfd693668d\"\r\n  ],\r\n  \"requiredResourceAccess\": [],\r\n  \"samlMetadataUrl\": null,\r\n  \"signInAudience\": \"AzureADMyOrg\",\r\n  \"tokenEncryptionKeyId\": null\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "1858"
+          "2296"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -528,28 +528,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 07:13:27 GMT"
+          "Wed, 27 Jun 2018 18:30:59 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "SwKd16gk0qQHqjuDH5ZMkxgOMor4FyG3yLeRoPVHqag="
+          "8FSoKn5C+xKnzMxVB24u9W0B3o/Ls6Mt3pri2fVg6OA="
         ],
         "request-id": [
-          "32345b5d-cbe7-451a-9942-2749f06cf147"
+          "fe50641a-8c49-4b3b-8d90-bf45bbfcf6cd"
         ],
         "client-request-id": [
-          "92956701-e83c-4eb2-8061-2f56cea973a2"
+          "39754c01-affc-43fb-b4c1-38338a898b9b"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "J4LOspUZQwcCjt_3vWb2xEE71GwTPw-qCnAp9PIgg1GQeCfsI-pqdQkaaW_qrDHVA_Y3uAhY-MrQzP1OMWIMmGcW5zYBPJ4NFI3jnbb3667nyKRxmYTovlDxzlfXo66nfwRT2y0qOREdOX5wj4ZEjgp7bUZproUZzyuld3WzQAqx07AE5oWSh-36K2RmD2bTc3zFS4tGU06Q7F9gjSpk8g.rpXoItQ-uM3Crcam41GZ_fHIaE_V9Gbtb047kxcjK0A"
+          "Z0mWlhO3YLmbAN3Jv75hOtDx-fAcNRyRxLzkXzqp4luQgO213GscExQBLLsRvOXk5OA3frJLYw_3PzyzMHt5G5xOegJgXKOFLx4cNRtcKj7Zi0s6kTsvxqDAKHiW0wgoAMnbptKhFjS2BLXu9YcCow.gunM-d54C3QmnU1K08E3qKkO4Dd4w1i_6ua6ihkvzIk"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -571,27 +571,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "759622"
+          "557371"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bd55abfd-e9c2-47ce-9c10-5c2259a0843b?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmQ1NWFiZmQtZTljMi00N2NlLTljMTAtNWMyMjU5YTA4NDNiP2FwaS12ZXJzaW9uPTEuNg==",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/b2bdde58-0bc8-4cf7-bd22-6c8ed3dafd83?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYjJiZGRlNTgtMGJjOC00Y2Y3LWJkMjItNmM4ZWQzZGFmZDgzP2FwaS12ZXJzaW9uPTEuNg==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "b4b796c9-e7be-4cae-aa88-bbf3cc12983d"
+          "4479c256-31fd-4496-a6ba-69514dbe912d"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "",
@@ -603,28 +603,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 07:13:28 GMT"
+          "Wed, 27 Jun 2018 18:30:59 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "j4TfrIcuXv6cz1XEFyVQir6Ee64fZtWPXl/gd62UzeM="
+          "TYqFcwXWOChFCYe863Ass3L6LUsoEAAlBpUkoGumdpw="
         ],
         "request-id": [
-          "a15d5b40-592f-4018-b93f-c11485215228"
+          "1211789e-0511-457b-aeb0-099879b86809"
         ],
         "client-request-id": [
-          "445cb589-e860-43e2-9e09-10131249a8f3"
+          "489d45a2-eff8-47c3-a167-4ccd018b8806"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "Ap9U3-PIInJWZpNjb_ITEzAmPXi64rOSBTUn32qVS4Q4fd6sRB-2_iDCzoMm1lAyEP1mxOIgLnia-2EVlmFnty8yi48oiBdCK-4RwBjYk8ZI4kyEl0-bUpsg4wRMtRgH0WeSgXmhGyp8fAmLSQCMBLy6vGxWxOc5_IRSIh_OMe9aFTjMSCIwyxwClsXChY2U8b1kq_4Zi-6-IciperVAgw.j5HmXUqqlkxOc95kNEnFQEqpzULskVMlKyT8gQFsK04"
+          "Pjkbp1kPuSPlJrbDGYq4bf_FojqIEqZzGiBe16f1mQDfmNLuw4XcaAg-hZfptJ8x5ounvMYN84VVCjXsxIQOuaf4DimGrMRX7FdWUjFDgTwvCVsCbzTZ6fGWkt5pUrJgJfTbP8tmaOvN5CLmKzl3kg.Cpe5JI3sCy-F-R4N3ankoDldC0CEfTxsH3JOrlCeJTw"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -646,7 +646,7 @@
           "ASP.NET"
         ],
         "Duration": [
-          "1667274"
+          "1207269"
         ]
       },
       "StatusCode": 204
@@ -654,11 +654,11 @@
   ],
   "Names": {
     "CanCRUDApplication": [
-      "javasdkappdc0573821"
+      "javasdkappfd693668d"
     ]
   },
   "Variables": {
-    "ServicePrincipal": "a971e5df-eeb7-4481-9bf7-e72e66a2ba12",
+    "ServicePrincipal": "39e3d217-cb72-4b90-8532-394a7e784d93",
     "AADTenant": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
     "SubscriptionId": "0b1f6471-1bf0-4dda-aec3-cb9272f09590"
   }

--- a/Tests/Fluent.Tests/SessionRecords/Fluent.Tests.Graph.RBAC.ServicePrincipals/CanCRUDServicePrincipal.json
+++ b/Tests/Fluent.Tests/SessionRecords/Fluent.Tests.Graph.RBAC.ServicePrincipals/CanCRUDServicePrincipal.json
@@ -4,7 +4,7 @@
       "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications?api-version=1.6",
       "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnM/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"availableToOtherTenants\": false,\r\n  \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"identifierUris\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\"\r\n  ],\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\"\r\n  ]\r\n}",
+      "RequestBody": "{\r\n  \"availableToOtherTenants\": false,\r\n  \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"identifierUris\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\"\r\n  ],\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\"\r\n  ]\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -13,21 +13,21 @@
           "378"
         ],
         "x-ms-client-request-id": [
-          "f6d8abf6-112a-42ea-b002-f04fb760e656"
+          "69d272e9-b93c-40ab-9b3a-12b6fbbd4dc4"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.Application\",\r\n  \"objectType\": \"Application\",\r\n  \"objectId\": \"1ee386e0-09f1-4fa9-a9e8-3d737ed1b219\",\r\n  \"deletionTimestamp\": null,\r\n  \"acceptMappedClaims\": null,\r\n  \"addIns\": [],\r\n  \"appId\": \"ec8b883e-e279-4b37-a29a-8df0f56ac37e\",\r\n  \"appRoles\": [],\r\n  \"availableToOtherTenants\": false,\r\n  \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"errorUrl\": null,\r\n  \"groupMembershipClaims\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"identifierUris\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\"\r\n  ],\r\n  \"informationalUrls\": {\r\n    \"termsOfService\": null,\r\n    \"support\": null,\r\n    \"privacy\": null,\r\n    \"marketing\": null\r\n  },\r\n  \"keyCredentials\": [],\r\n  \"knownClientApplications\": [],\r\n  \"logoutUrl\": null,\r\n  \"oauth2AllowImplicitFlow\": false,\r\n  \"oauth2AllowUrlPathMatching\": false,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"id\": \"8073ece8-3069-46c6-9146-322519e2fbb0\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"oauth2RequirePostResponse\": false,\r\n  \"optionalClaims\": null,\r\n  \"passwordCredentials\": [],\r\n  \"publicClient\": null,\r\n  \"recordConsentConditions\": null,\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\"\r\n  ],\r\n  \"requiredResourceAccess\": [],\r\n  \"samlMetadataUrl\": null,\r\n  \"tokenEncryptionKeyId\": null,\r\n  \"isDeviceOnlyAuthSupported\": null\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.Application/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.Application\",\r\n  \"objectType\": \"Application\",\r\n  \"objectId\": \"bc666b96-bd29-4675-813e-bf4b1e3b13d3\",\r\n  \"deletionTimestamp\": null,\r\n  \"acceptMappedClaims\": null,\r\n  \"addIns\": [],\r\n  \"appId\": \"f6b5daaa-69aa-4ad0-8c31-0c59b6586f39\",\r\n  \"appRoles\": [],\r\n  \"availableToOtherTenants\": false,\r\n  \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"errorUrl\": null,\r\n  \"groupMembershipClaims\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"identifierUris\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\"\r\n  ],\r\n  \"informationalUrls\": {\r\n    \"termsOfService\": null,\r\n    \"support\": null,\r\n    \"privacy\": null,\r\n    \"marketing\": null\r\n  },\r\n  \"isDeviceOnlyAuthSupported\": null,\r\n  \"keyCredentials\": [],\r\n  \"knownClientApplications\": [],\r\n  \"logoutUrl\": null,\r\n  \"logo@odata.mediaContentType\": \"application/json;odata=minimalmetadata; charset=utf-8\",\r\n  \"logoUrl\": null,\r\n  \"oauth2AllowIdTokenImplicitFlow\": true,\r\n  \"oauth2AllowImplicitFlow\": false,\r\n  \"oauth2AllowUrlPathMatching\": false,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"id\": \"9494d843-fb44-4816-a4c8-87c32cfba7b9\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"oauth2RequirePostResponse\": false,\r\n  \"optionalClaims\": null,\r\n  \"orgRestrictions\": [],\r\n  \"parentalControlSettings\": {\r\n    \"countriesBlockedForMinors\": [],\r\n    \"legalAgeGroupRule\": \"Allow\"\r\n  },\r\n  \"passwordCredentials\": [],\r\n  \"publicClient\": null,\r\n  \"publisherDomain\": null,\r\n  \"recordConsentConditions\": null,\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\"\r\n  ],\r\n  \"requiredResourceAccess\": [],\r\n  \"samlMetadataUrl\": null,\r\n  \"signInAudience\": \"AzureADMyOrg\",\r\n  \"tokenEncryptionKeyId\": null\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "1855"
+          "2157"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -39,31 +39,31 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:35 GMT"
+          "Wed, 27 Jun 2018 18:01:42 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/1ee386e0-09f1-4fa9-a9e8-3d737ed1b219/Microsoft.DirectoryServices.Application"
+          "https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/bc666b96-bd29-4675-813e-bf4b1e3b13d3/Microsoft.DirectoryServices.Application"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "gzTHd9xPT6UpzqL1VdRsA3bqkd3Ju1OXrLwpKneHrpg="
+          "gXfFarcv2ysN8TtqVPgD1PYEnzY+oOLIPXpP5S4Cj3o="
         ],
         "request-id": [
-          "458bdf97-f31a-412a-9e04-8c5d2855bca1"
+          "8dad14ad-8513-412a-8798-b5c859e56553"
         ],
         "client-request-id": [
-          "e8fde505-81ed-4ccb-8b1a-ab76438ca18f"
+          "9df09b05-3ea0-4435-8b60-307974b93467"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "Wuhe8HCgkCDmKITSNAExLlVLE21RIDTWu-nA1GaKGi1zDhWQWh5sFYyicA1c4GDSO57yo6OBF76lqSB6PNwiM-IefQVgtpUF8jbACc9oyo9whx5dL1pTaXPqQ9IVj3BCu4wWZLPJ_uRqPCFnJ087athfNrr6LzFWcekfdmBv5tlyZ16ztO55rKu-i-S5pgLoNz6VJh3Wuef8ICVFSh6RXA.8Y7NjcjCu1LkvF4QEwNgsYXSVB6vtKMtrgY9X6Ag-fY"
+          "moqtbCz3C0bDdfNE8L-6SDs_GNmNnxvE9EIzeboUFpD4z-LXgagbg_kVpu5RELtsiIwoCWNbqrIP7q3b09smJZvLty7rRpf1Gn3y9JMKv0XuwLBPknZS884pSbdQU5DeuBvaGCFVE97wZ6y0PmP7EA.ut2pg4QAxEXFBe0GPVUGX_-fYvXw9syFFjh_c5z_2tE"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -85,27 +85,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "6721243"
+          "2993270"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/1ee386e0-09f1-4fa9-a9e8-3d737ed1b219/keyCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvMWVlMzg2ZTAtMDlmMS00ZmE5LWE5ZTgtM2Q3MzdlZDFiMjE5L2tleUNyZWRlbnRpYWxzP2FwaS12ZXJzaW9uPTEuNg==",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bc666b96-bd29-4675-813e-bf4b1e3b13d3/keyCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmM2NjZiOTYtYmQyOS00Njc1LTgxM2UtYmY0YjFlM2IxM2QzL2tleUNyZWRlbnRpYWxzP2FwaS12ZXJzaW9uPTEuNg==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "4486dd53-6ca8-488e-99b1-2ea87008c2c0"
+          "21db4d0f-b773-463f-b1e1-7143faad0827"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": []\r\n}",
@@ -123,28 +123,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:35 GMT"
+          "Wed, 27 Jun 2018 18:01:43 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "X7JJrDJZ6J5u3UjAG6S964BeoRqIrZ+Y1/baVMmjI9U="
+          "s2UwUVi+htM/n2YkhPwXRPeUZqg0DtftoAt5dzpH0b8="
         ],
         "request-id": [
-          "80b0e8d2-e715-4719-a945-08fc91e77498"
+          "7320eefb-11a2-424d-8952-c90ea9d82536"
         ],
         "client-request-id": [
-          "b2bbe560-ae95-40d0-a467-8b9faca090a5"
+          "9e0fd970-8f91-4665-a8c6-a9d0221739af"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "huDwjQhXGyVTCigyVxBawOtfn95HceVI6lwMCFhIE1T38Bg1tNCUKGH-tCTqlJHH94ouHy6Zr7USZBfm2qIzRfRxV8IyR5WHYCOsbGFxnO0xmCbUFOS_k7YLcfqAN7El76tn2VJQH2wEdNVxz_PunUy56ng_lFN5jTAIlRHE3AtY7RHZ6xs_JbVIxyqPLJdSIn9ql20FhoT15t44cNpNuA.BSbiFT2kksDAaM1mbuywxTQsclcaRzlxAtSfaBXRZM0"
+          "MSQdV6zlUfcCnWgWwfqOKU8pa9GZ2nLtPIza1SPO5JCA5HJmQaFzvLuM9CLmjgjQRDYMgdrERQvpaH-5WZGrGcYNu6p-kDhW2ndYb51V0NGdlDBnD4EEJ-3_51PTSVut_HsqxL_naAeI4QABq6474Q.xn0YTZT8IndNtMTnYIIW74ZE1ty8JlGa4eCvIbZ2fcY"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -166,27 +166,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "963414"
+          "468878"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/1ee386e0-09f1-4fa9-a9e8-3d737ed1b219/keyCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvMWVlMzg2ZTAtMDlmMS00ZmE5LWE5ZTgtM2Q3MzdlZDFiMjE5L2tleUNyZWRlbnRpYWxzP2FwaS12ZXJzaW9uPTEuNg==",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bc666b96-bd29-4675-813e-bf4b1e3b13d3/keyCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmM2NjZiOTYtYmQyOS00Njc1LTgxM2UtYmY0YjFlM2IxM2QzL2tleUNyZWRlbnRpYWxzP2FwaS12ZXJzaW9uPTEuNg==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "56484193-34d7-4fb5-9a9d-0ecefba14687"
+          "27d199c5-2517-4b18-b4ff-7095f1be287d"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": []\r\n}",
@@ -204,28 +204,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:40 GMT"
+          "Wed, 27 Jun 2018 18:01:46 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "K7+AvfaamY7DwcxlbHLJ+P0optdxEzfgDUCXy1QyENk="
+          "sddddXJCDv27jmu91AjCY4cjIA04nWQAsEkxbrysAOg="
         ],
         "request-id": [
-          "a33f8f45-aadd-4b6c-bcfe-6fcf9a7dbf6a"
+          "df0b9587-246f-4de1-ac78-9aa37c6d5905"
         ],
         "client-request-id": [
-          "a3563613-e8c4-4880-874f-f07482990cac"
+          "a3e685c5-419f-4c5c-9bfe-adf128cadd77"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "0g4FLvTjsA-ZDVswI6AiYfwYNbG0igFk4oSzcbTPTBNor5s7DAM3aTV0YWQoggtfBaFGqUW5G3Jtj1XuQExclsU8r_942k7fJejbFmhNVRZirpX2FawjgH4VNvax3UixZ-bCtgcI19JgL_5FDlHMaRVWffSYPzSw0xRdWNQPfq5JaxbNWC5AtQHXfykv-oac8UFQrvKmfl2nZCD0RhFkJg.bK2QaSZmPe3_Hf4q-yxBllj9EZlZShvpiVmqnV3s1-s"
+          "boevJ7L9q7ZA7S48doe7Hdu4LJyChugogxi_qXP3BtyaD1SZ2mAgDwSEkKOcJmFI9AX8HSqCMuAmWBPyXPwgAHs5xYkVpJgGcrZ86LpN1HxF1w1LQV0P_vbDzUx62jU-LM1uRu2senLtTRMrEThFbA.Bsg2Phvk6wy-qEdPf2OEVmWS6Wrlgws3NSRz29aFkbk"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -247,27 +247,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "571045"
+          "2251309"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/1ee386e0-09f1-4fa9-a9e8-3d737ed1b219/passwordCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvMWVlMzg2ZTAtMDlmMS00ZmE5LWE5ZTgtM2Q3MzdlZDFiMjE5L3Bhc3N3b3JkQ3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bc666b96-bd29-4675-813e-bf4b1e3b13d3/passwordCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmM2NjZiOTYtYmQyOS00Njc1LTgxM2UtYmY0YjFlM2IxM2QzL3Bhc3N3b3JkQ3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "68c7b3a0-840c-41b5-b3ce-dddfcc829433"
+          "f5af1533-af99-4c4a-ad21-477e32ec5c62"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": []\r\n}",
@@ -285,28 +285,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:35 GMT"
+          "Wed, 27 Jun 2018 18:01:43 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "szH7pzsrbRAPE86vyzFuSbzdmQUBfutTPp8vrjH1GSY="
+          "vPettSiUstOmmenKCofUY/RtXhXy1JLj54Gv/HPGCX8="
         ],
         "request-id": [
-          "72ba35e5-69e0-45c2-820e-d574cb74129d"
+          "0c1edfc5-b17a-4158-81b5-6b9fab29fd11"
         ],
         "client-request-id": [
-          "edeb3f18-c4e2-4068-8613-fa551bf73389"
+          "a8e4ad82-4b79-45bd-80f2-8a57d9d233a1"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "aVDP1hgVBXOvlwRmPjliGQ0VGyRpNVRxIFprxO5iQEhbRjvjt_uljwsPozBMdmMjrEHvnbAjkE91ica_0YfKdE-FbIW2XX8Oe_yXUw5QYdkZ7WLTm3nGbOmnVg5tou0Qz-AGdbuEMmdmatTLqsGOHWV6dC7epBtjkiJO2WtKKMqJ7ncE_8NRvLijgTJqO5B3nybCNucpwiJ-KPwXUBcTvg.RA0QoW2uLAi08uhr_xsIKfU7KArnRZSdYYUz3v1slRs"
+          "fIfJF4sFV045Ztg2d4uGv4_qGA-NP7VYbftOc7Sb3bhzBKliy0op7ShDnxzp6mpYeG0E6bfGRgkjXuNpjlktkPvRl8MM9_MAT9mq6qAGpHHJ6TLPrY6VbSHE0lFkjBi576D6yGUlKsHPGBjz_bwpKw.m34DX4S28eQ3mPiib9w7SvZt0LBDyL3w3l-dr6i-V6U"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -328,27 +328,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "615645"
+          "472350"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/1ee386e0-09f1-4fa9-a9e8-3d737ed1b219/passwordCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvMWVlMzg2ZTAtMDlmMS00ZmE5LWE5ZTgtM2Q3MzdlZDFiMjE5L3Bhc3N3b3JkQ3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bc666b96-bd29-4675-813e-bf4b1e3b13d3/passwordCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmM2NjZiOTYtYmQyOS00Njc1LTgxM2UtYmY0YjFlM2IxM2QzL3Bhc3N3b3JkQ3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "2b82ba0d-73ed-4d8a-9006-dfa42dd7f5a7"
+          "99052cd2-fb89-4a41-9bd1-238d8868aacc"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": []\r\n}",
@@ -366,28 +366,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:40 GMT"
+          "Wed, 27 Jun 2018 18:01:46 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "Llgy9/ab0slLzBlr4d1Q8lNJvx6g8YZ9cwM/rai9BcE="
+          "pi9WNtEHQL/5J5R7YGiyzL38BqSp9WQ7lEmNjbCD2mg="
         ],
         "request-id": [
-          "24fc01e3-eee0-45af-bf99-469a27b7dd87"
+          "236b30c6-7efc-4a44-8a2c-6887c1b4acd2"
         ],
         "client-request-id": [
-          "9bd0b723-f41a-4ec4-bacf-e745d927af9b"
+          "1cb4f2e2-b3ee-442d-81e4-35e2dd9a7d91"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "R7J3yIr4gz2S44TyqATqAucUf6ahf-1sCRczZ4fTqja5xih0XdRNVvHrPqP1BTjxDPguPqLQmSGkBFzETEmQwtR6clYoYreg5-U34Xwu6UAsaO1OVzR2NftfJvBhfxSKffa8U_xHEv3yii0qkdCUfFWHzK4Ho9hLzv3p27YRZQpIoZTfPs_ty_df-acWT0BQAJ-6WAA1zzFGkoVpFygSGA.a6AHSV_AxkPzyZgdlDjeM4ypOrIZn8UTo1YBT4jhkqo"
+          "6c5QBl1QQsFPTv0QB9SvVRiGT7w2PowLzxpGrLn8B_dM2NUW-NoGUtmWjf9GRA-fw8VfT1qemyiIDqKoFTgg6TidIDCIzjEDDDWWkJK-otOPFbfrwgQXyzJUvOYIvvAXs0y3GfO7YJ8OAd6DUgLyOg.LyMIrQt40qoyyo8O65tbiPV42TmUwd7I5SnuTp_BLXA"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -409,7 +409,7 @@
           "ASP.NET"
         ],
         "Duration": [
-          "548054"
+          "1568678"
         ]
       },
       "StatusCode": 200
@@ -418,7 +418,7 @@
       "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals?api-version=1.6",
       "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscz9hcGktdmVyc2lvbj0xLjY=",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"appId\": \"ec8b883e-e279-4b37-a29a-8df0f56ac37e\",\r\n  \"accountEnabled\": true\r\n}",
+      "RequestBody": "{\r\n  \"appId\": \"f6b5daaa-69aa-4ad0-8c31-0c59b6586f39\",\r\n  \"accountEnabled\": true\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -427,21 +427,21 @@
           "82"
         ],
         "x-ms-client-request-id": [
-          "e7a9b425-f3dd-406e-8fab-8a53563be7bd"
+          "a9dc996c-0133-4f23-afeb-f66cfb538f14"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.ServicePrincipal\",\r\n  \"objectType\": \"ServicePrincipal\",\r\n  \"objectId\": \"b0c31ede-cb7a-4ca7-b7de-d065e66a342b\",\r\n  \"deletionTimestamp\": null,\r\n  \"accountEnabled\": true,\r\n  \"addIns\": [],\r\n  \"alternativeNames\": [],\r\n  \"appDisplayName\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"appId\": \"ec8b883e-e279-4b37-a29a-8df0f56ac37e\",\r\n  \"appOwnerTenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n  \"appRoleAssignmentRequired\": false,\r\n  \"appRoles\": [],\r\n  \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"errorUrl\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"keyCredentials\": [],\r\n  \"logoutUrl\": null,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"id\": \"8073ece8-3069-46c6-9146-322519e2fbb0\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"passwordCredentials\": [],\r\n  \"preferredTokenSigningKeyThumbprint\": null,\r\n  \"publisherName\": \"AzureSDKTeam\",\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\"\r\n  ],\r\n  \"samlMetadataUrl\": null,\r\n  \"servicePrincipalNames\": [\r\n    \"ec8b883e-e279-4b37-a29a-8df0f56ac37e\",\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\"\r\n  ],\r\n  \"servicePrincipalType\": \"Application\",\r\n  \"tags\": [],\r\n  \"tokenEncryptionKeyId\": null\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.ServicePrincipal\",\r\n  \"objectType\": \"ServicePrincipal\",\r\n  \"objectId\": \"9385acae-5eb2-4ea4-9d0d-ff88cd259d48\",\r\n  \"deletionTimestamp\": null,\r\n  \"accountEnabled\": true,\r\n  \"addIns\": [],\r\n  \"alternativeNames\": [],\r\n  \"appDisplayName\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"appId\": \"f6b5daaa-69aa-4ad0-8c31-0c59b6586f39\",\r\n  \"appOwnerTenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n  \"appRoleAssignmentRequired\": false,\r\n  \"appRoles\": [],\r\n  \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"errorUrl\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"keyCredentials\": [],\r\n  \"logoutUrl\": null,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"id\": \"9494d843-fb44-4816-a4c8-87c32cfba7b9\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"passwordCredentials\": [],\r\n  \"preferredTokenSigningKeyThumbprint\": null,\r\n  \"publisherName\": \"AzureSDKTeam\",\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\"\r\n  ],\r\n  \"samlMetadataUrl\": null,\r\n  \"servicePrincipalNames\": [\r\n    \"f6b5daaa-69aa-4ad0-8c31-0c59b6586f39\",\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\"\r\n  ],\r\n  \"servicePrincipalType\": \"Application\",\r\n  \"signInAudience\": \"AzureADMyOrg\",\r\n  \"tags\": [],\r\n  \"tokenEncryptionKeyId\": null\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "1807"
+          "1839"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -453,31 +453,31 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:35 GMT"
+          "Wed, 27 Jun 2018 18:01:43 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/Microsoft.DirectoryServices.ServicePrincipal"
+          "https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/directoryObjects/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/Microsoft.DirectoryServices.ServicePrincipal"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "K7+AvfaamY7DwcxlbHLJ+P0optdxEzfgDUCXy1QyENk="
+          "Ejlln//HW8QHQEvfdHqbS3KozJkF5qO/py2QoUOMx9s="
         ],
         "request-id": [
-          "e48cfa58-474d-430c-a063-1441e47b7b88"
+          "62c36548-b1b1-49c9-b7c7-44c64610bbd0"
         ],
         "client-request-id": [
-          "0c31aa96-bf22-44fe-9077-ac8794fd5863"
+          "7dd0b4da-a754-4691-9038-2ab1d721f4f9"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "rmBhKVLdpL6XoHPD19tNEXij-AqKMP7xcqGU-Eo_M22mYcMzD_nJKaZakoA3OLuuH8DpEXHz_iZWXOU_Pfw4ShoCpK0qFNin7QJdFNvqGHyroe5Ms72uFahy46rbS5K5516oZPVRhZ9DGTF7IaXYFu-s6qdrS85CYNhzkmFe7beTlSzXEsLWVkvFPOGdLy_u44r6LSPdhkz59x8vm4nD0A.q3tG6F0szDEcfqg1kiWgLdinNhtmR2c5MDTR6f-8P2w"
+          "nAJ_7S_SiGdSHeiztPTpvm45ts9cI6TsuRDPtKYxfyJPzaeSSbBFPbWSHJIj0kDWyt28rWGp2eVQgMHcQMzrGF6S2x8IalrqwPTdpVkARXjqZ0K1Gf5g7hPEspa5yfS9osV1st4w2Z1tLvhFeQYhlw.4iQa-uTf7gU2f2A0u0TyMDgcG_p4kgFih5kULtfP-0M"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -499,33 +499,33 @@
           "ASP.NET"
         ],
         "Duration": [
-          "3284517"
+          "2230811"
         ]
       },
       "StatusCode": 201
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/passwordCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/keyCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "PATCH",
-      "RequestBody": "{\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BwYXNz\",\r\n      \"startDate\": \"2018-01-10T12:14:34.9270661Z\",\r\n      \"endDate\": \"2019-01-10T12:14:34.9270661Z\",\r\n      \"value\": \"StrongPass!12\"\r\n    }\r\n  ]\r\n}",
+      "RequestBody": "{\r\n  \"value\": [\r\n    {\r\n      \"startDate\": \"2018-06-27T18:01:42.7760486Z\",\r\n      \"endDate\": \"2018-06-28T18:01:42.7760486Z\",\r\n      \"value\": \"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDd1RDQ0FhbWdBd0lCQWdJRUprNTJ1REFOQmdrcWhraUc5dzBCQVFzRkFEQVJNUTh3RFFZRFZRUURFd1p0DQplVlJsYzNRd0hoY05NVFl4TVRFeU1ERXhNekkyV2hjTk1qWXhNVEV3TURFeE16STJXakFSTVE4d0RRWURWUVFEDQpFd1p0ZVZSbGMzUXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDYm56SkYzYysvDQpzY2JnUnluc2l4eG1XbDNHZFppUUh2b0FjVWJXZUdkbDF1bzBSVDZYeThCQ0tkWENCUW9ZbXhuZzNYYnZTS2RiDQp2UGUyYmtHVDlBMDhxVTh5VXFUMGJFSXFXNUZCZ3g1ZEVzdzRUeCtuOXA3UWhKTWF3Nlg1NFZ1SlVieVVwNERaDQp2VGxlOTluMDBqR0hwdDZUQndqb0VJNnNET1M3WG5lblk5WVIxR1hEY00zcVdidklXVHJ6SmFxeXMxUmdTYnhnDQpjUklMbjg4NVZaWkx1dXlqVTZXaEpRRmZ4L2kzR1hLVDNaUDhyVTNlNmQ3cTBQalZBS3lGd2FNTlZlVTRWbURpDQo3a25HaHlDODRJWW8xT0ZLc0FjU1ZDYXhkU1FiT0dhZXh2RmFqMmpqb0tmdlkzZG40aW9vM3lJelNNSmdsZk1BDQpISFgveHpUa3gyN2xBZ01CQUFHaklUQWZNQjBHQTFVZERnUVdCQlNDUXVicXhkSVBVdS9QRVdxUmxTWHBLTEZ1DQpxVEFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQ3A2WUNLdDhGamtQdW5sQ0lKUFZZeFJZUTNzdDdHL0pGMnk5DQowRWlQWlc4THNCOFFTL0dQcmNoQmFaZE9pMVNNTGtEdlMyQnozN3VuSks3WUY2WC9JWG1nYWNDSkpjTnlXci8wDQpJdURUNGYwaHUzVCtYeWZlMFRVeFZJQzRDYjhpY3c1SXBGMkVhZ1ZhY0VSVFpHQi91MzhZNzdGYTNKUlN4NHdaDQpuc0hUbVA0SlNLdU94UlprbkR3NS9nSEdIZkhyKzlueWNOSjdJSHJZS0tDRUVna2hEVXZVYXgzZk4zVFd5WmFwDQpSOThTK1JRYUozckxhTmlOcVZqdUdyYkhqUmVRaWtUdFp3Q3RscE04Vkhvdml5eVRVRTd4a2VrTTJwNFloRHBEDQpaRE4raTJPZ1VLc1NLbUR3clpUQzczMkQwRzdyODBmbDk2ZXpOTTlPN3FoNDU3aWhWQT09DQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tDQo=\",\r\n      \"usage\": \"Verify\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\"\r\n    }\r\n  ]\r\n}",
       "RequestHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "213"
+          "1643"
         ],
         "x-ms-client-request-id": [
-          "a7d80297-6cd4-4dcd-8ac6-934f2b4ebedd"
+          "74a80451-d52c-4e69-bc7d-7a19ba67429a"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "",
@@ -537,28 +537,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:37 GMT"
+          "Wed, 27 Jun 2018 18:01:43 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "2DD9Uu67ybR8Pd6jBxWLoYGX++26Si/Rh4KiODEAByo="
+          "aLjul60AojNkmrHXU2K8UCWjsiSBDyBxA+NSaz2RTqQ="
         ],
         "request-id": [
-          "c4ce2bd3-b0f4-46ae-b454-8c5bce3a8f4d"
+          "02874dc2-d1a3-40d3-9014-eefa0a3f4c60"
         ],
         "client-request-id": [
-          "fdd0dcb3-8cce-417f-b8ab-2081e2f72106"
+          "9bccb507-3a1d-4f1c-98bd-796a28bae4e4"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "OT55h2WoahykqILa06HLLwuQQlVX1XddxaabJcsjxojfQnKbd7ANypLtVhTzKy4p4ND3d1AbBaE5XNEFCc1bi_657GB5BoCYlPAHA82ogx_kihJO4Z1rJ0TFBMl2AHE8LYCONNgjFmNAlEzfc0idCjbnMRFRSmpZtY2yVyFMOks5kmjXOOi1S6utPReYNj59rc8wP5f0LRDUhkcB330iSQ.NktXx_pm40F_k0mDaLnJQknpFlbI_11J5mTeuHfco4A"
+          "_GgdFV46LniwvgxX5V4o-tWPzvVDlBCyXMWsD3BvGCh4fM5l47oDCKmGyS9rBnFwfU4Hij2oiPQSymDJ_wl2ecScaQZqE1a-674tgRiY2kBzuLvghuB-9d539yKRJSaeRaFH8VMv9Fz22-aZAukeeg.jhoxbElYmH3HIriOpmJ7rWc-HtroLCQ7FVldM2mKXkU"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -580,14 +580,176 @@
           "ASP.NET"
         ],
         "Duration": [
-          "3239178"
+          "1969019"
         ]
       },
       "StatusCode": 204
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/passwordCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/keyCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
+      "RequestMethod": "PATCH",
+      "RequestBody": "{\r\n  \"value\": [\r\n    {\r\n      \"startDate\": \"2018-06-27T18:01:42.7760486Z\",\r\n      \"endDate\": \"2018-06-28T18:01:42.7760486Z\",\r\n      \"keyId\": \"8938ad9f-1fb7-4dc1-9920-3cb02519419f\",\r\n      \"usage\": \"Verify\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"value\": null\r\n    },\r\n    {\r\n      \"startDate\": \"2018-06-27T18:01:45.9053922Z\",\r\n      \"endDate\": \"2018-06-29T18:01:45.9053922Z\",\r\n      \"value\": \"MIICwzCCAaugAwIBAgIEAeU3rDANBgkqhkiG9w0BAQsFADASMRAwDgYDVQQDEwdteUNlcnQyMB4XDTE2MTExMzE4NDkyOVoXDTI2MTExMTE4NDkyOVowEjEQMA4GA1UEAxMHbXlDZXJ0MjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAKoFamQIOH3rawbj8cClxT5t7qfOlnJC7zOApTUOvIPYvRq7jA/Q0SqSKgNSNYhdQDN4qFwbLDDYI2GKu/Woc41IjPq22G65CHT065yfm71I0EkBPqMylX7O3ROvcUqL5qhIsYRq8vHxRDkakFtF8XDCnBt5h5O5Z7M71Vrk/y+qQXhW3Mv0iCYGWgR6RXAXB9akVOYMRpFRl9JtRr3eqauw/Y2H+7qN0KO+NhHD466blyV2n7GbV4WAs/3Ef4Hn2YWFNqBWaHGAiB/J7JkzoXIiJLdibnbbsySsUPqJLEjgSKoGUMW5Hv3RqOypohk//+ZM1tQ5NqzjtzDvgzMYkocCAwEAAaMhMB8wHQYDVR0OBBYEFBGBkNRKdeYcVPKuwncc1IG3gpFhMA0GCSqGSIb3DQEBCwUAA4IBAQBSMDWvfs380j2A7pF9B902g6ii3NTypzqBoGu1hHjiannyP+dWmwUU7WSWkQomCILST2Y0Kc76icHz8D5SmLH1ITnwO3F3urJ7eXTybh1acYgjZUE61D1l9dCtLIsWOypQ0OvlOiJy3Mrq6S1p6RtCC2Ysol7jR5fxc7TwCexO4jL6qqCAKnTc90rukWzScEExwTzZOmN5zXwbRHTdos2wo832A8Twb20oyuXqLDiWupC3AQK/2sE3PbJZCsaPbsq09DYLyU44NQsdQq2uyzE3vCmZZorUHEO/NQR9bF06rqa3k0aI7as1naKM/m6RAhKfTuLITBSV2s4rWUInRToS\",\r\n      \"usage\": \"Verify\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\"\r\n    }\r\n  ]\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "1510"
+        ],
+        "x-ms-client-request-id": [
+          "6a13373a-f287-43d5-a658-9ffce77c44ab"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 27 Jun 2018 18:01:45 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
+        "ocp-aad-diagnostics-server-name": [
+          "UJod7VmkPiqRZ3LL8q1JqdoyPpXCav9KRxab7im3lsM="
+        ],
+        "request-id": [
+          "e2dcf036-ec3d-495c-ae2b-ef5916e0b643"
+        ],
+        "client-request-id": [
+          "8f791fed-d364-4d93-b6e9-88f99512ef5a"
+        ],
+        "x-ms-dirapi-data-contract-version": [
+          "1.6"
+        ],
+        "ocp-aad-session-key": [
+          "xzwWepuZwwvIbXR6h-_1ToKDzXvBwv7NKXeMKwPzrWbgOA8HjqvhhAu4QFToRRzJUPrf0raPvuseqV5D4pQSh2QTTAG-Dh4-kOgnbM4-BWLFymb7O_NRak6N2_SSxajbe3pKvKYNosQGRswJjGNFoQ.TH_WoDXvkPDHCPCm522b0F5w5jHpvlxHXv6hDmXoTSo"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "1.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Access-Control-Allow-Origin": [
+          "*"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "X-Powered-By": [
+          "ASP.NET",
+          "ASP.NET"
+        ],
+        "Duration": [
+          "2813696"
+        ]
+      },
+      "StatusCode": 204
+    },
+    {
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/passwordCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
+      "RequestMethod": "PATCH",
+      "RequestBody": "{\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BwYXNz\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7730739Z\",\r\n      \"endDate\": \"2019-06-27T18:01:42.7730739Z\",\r\n      \"value\": \"StrongPass!12\"\r\n    }\r\n  ]\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "213"
+        ],
+        "x-ms-client-request-id": [
+          "97aa8c95-2349-40c3-80e9-f4ef857e73af"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 27 Jun 2018 18:01:43 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
+        "ocp-aad-diagnostics-server-name": [
+          "zPeOuJeNLZ5N5CAKU8XN6jsJ5sC6cSv6Gh6WpNy3E8g="
+        ],
+        "request-id": [
+          "ad3bbcb9-26c1-4229-bae8-f3d470b7acc6"
+        ],
+        "client-request-id": [
+          "98786097-b471-48dc-9864-7abcdc1cb235"
+        ],
+        "x-ms-dirapi-data-contract-version": [
+          "1.6"
+        ],
+        "ocp-aad-session-key": [
+          "HGLvFqk9CyAVaMpH6z2dFBxw3iVO35cLgaE3ZPLKG1x7tT9uDkltMBQNN1BHsY-28cRDF8gBdJsn0Sm8haCORvNvqeZbScfWV8zQcGekOf7XL-2yBvyvpnm9InV06ibXcvWVydrITli4jf5x8ymIgQ.vhSvBvLotKfaLfickBgwpNrgSgAN6Of0SKsrwpKfqow"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "1.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Access-Control-Allow-Origin": [
+          "*"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "X-Powered-By": [
+          "ASP.NET",
+          "ASP.NET"
+        ],
+        "Duration": [
+          "2147263"
+        ]
+      },
+      "StatusCode": 204
+    },
+    {
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/passwordCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
       "RequestMethod": "PATCH",
       "RequestBody": "{\r\n  \"value\": []\r\n}",
       "RequestHeaders": {
@@ -598,15 +760,15 @@
           "19"
         ],
         "x-ms-client-request-id": [
-          "9e961971-a41e-4e76-8af5-435a794ae54b"
+          "a856189e-81eb-42c1-829c-f9439f98577b"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "",
@@ -618,28 +780,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:38 GMT"
+          "Wed, 27 Jun 2018 18:01:45 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "K7+AvfaamY7DwcxlbHLJ+P0optdxEzfgDUCXy1QyENk="
+          "0sfE/ORXQruXagUwgN6LKCMJnfSNsPKIg39HCVmIqe8="
         ],
         "request-id": [
-          "cd35dda6-9abd-44a9-b5aa-498ab24d0771"
+          "d2c41fde-d16b-4f0c-8b4f-6f6d186359a2"
         ],
         "client-request-id": [
-          "6c20a597-a12d-4f57-accb-a0232d237ec3"
+          "741c365f-fb87-4888-b340-ce68e8794884"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "BGX5fc1tGpNko-kPjoplSvj1yZIUdszQY5qrepxy_GxyL2t1SRqomjhjl2Q8OZN31V7DRXBLSxVXycHa3KzJWkx-s_pHYekmteaAJMfXfP5WluxvDgWUgqEP_9QSFFjShNWu4BbM9HmEBNONdYSMDkINURDta-NjaVjCjQjwqV0ho3YyqJR77N4nmLt76Z0pMNbrIfC2D8SEXl9zbwvGTA.HhnyffXk7ZCk3FWieWcG5ZLOa75jiNcQP6J5ChYpoCk"
+          "Xwsg_Zv-nTwS5Us5zCzg7jXEyPnTVexTR5lAEFX7HfQTjM4WfnsQzWDqytOk8oYZ1HKzth6JWg8S-teXvnedpw7k0yoGlfLrVrIollzSlkb_6QGSmjRr98ZiG8lL_y0sHIIwf_NZMIH_0_WdMUxSYg.ydNjrmO121-gxl4qfPLTY0K7hTCuMTvJhJpKfImtQ_0"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -661,33 +823,33 @@
           "ASP.NET"
         ],
         "Duration": [
-          "3549889"
+          "1817634"
         ]
       },
       "StatusCode": 204
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmI/YXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDg/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "d25a806d-0a26-4557-81fd-d0656a7704c9"
+          "44c82754-b2a1-4382-9c43-0d41c52ad624"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.ServicePrincipal\",\r\n  \"objectType\": \"ServicePrincipal\",\r\n  \"objectId\": \"b0c31ede-cb7a-4ca7-b7de-d065e66a342b\",\r\n  \"deletionTimestamp\": null,\r\n  \"accountEnabled\": true,\r\n  \"addIns\": [],\r\n  \"alternativeNames\": [],\r\n  \"appDisplayName\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"appId\": \"ec8b883e-e279-4b37-a29a-8df0f56ac37e\",\r\n  \"appOwnerTenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n  \"appRoleAssignmentRequired\": false,\r\n  \"appRoles\": [],\r\n  \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"errorUrl\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"keyCredentials\": [],\r\n  \"logoutUrl\": null,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"id\": \"8073ece8-3069-46c6-9146-322519e2fbb0\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"passwordCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BwYXNz\",\r\n      \"endDate\": \"2019-01-10T12:14:34.9270661Z\",\r\n      \"keyId\": \"435ad9c7-a501-4921-b6bc-ecc0cf4f6597\",\r\n      \"startDate\": \"2018-01-10T12:14:34.9270661Z\",\r\n      \"value\": null\r\n    }\r\n  ],\r\n  \"preferredTokenSigningKeyThumbprint\": null,\r\n  \"publisherName\": \"AzureSDKTeam\",\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\"\r\n  ],\r\n  \"samlMetadataUrl\": null,\r\n  \"servicePrincipalNames\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n    \"ec8b883e-e279-4b37-a29a-8df0f56ac37e\"\r\n  ],\r\n  \"servicePrincipalType\": \"Application\",\r\n  \"tags\": [],\r\n  \"tokenEncryptionKeyId\": null\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.ServicePrincipal\",\r\n  \"objectType\": \"ServicePrincipal\",\r\n  \"objectId\": \"9385acae-5eb2-4ea4-9d0d-ff88cd259d48\",\r\n  \"deletionTimestamp\": null,\r\n  \"accountEnabled\": true,\r\n  \"addIns\": [],\r\n  \"alternativeNames\": [],\r\n  \"appDisplayName\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"appId\": \"f6b5daaa-69aa-4ad0-8c31-0c59b6586f39\",\r\n  \"appOwnerTenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n  \"appRoleAssignmentRequired\": false,\r\n  \"appRoles\": [],\r\n  \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"errorUrl\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"keyCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-06-28T18:01:42.7760486Z\",\r\n      \"keyId\": \"8938ad9f-1fb7-4dc1-9920-3cb02519419f\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7760486Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ],\r\n  \"logoutUrl\": null,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"id\": \"9494d843-fb44-4816-a4c8-87c32cfba7b9\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"passwordCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BwYXNz\",\r\n      \"endDate\": \"2019-06-27T18:01:42.7730739Z\",\r\n      \"keyId\": \"c21175fa-810b-4e71-958a-e333ea0b28fc\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7730739Z\",\r\n      \"value\": null\r\n    }\r\n  ],\r\n  \"preferredTokenSigningKeyThumbprint\": null,\r\n  \"publisherName\": \"AzureSDKTeam\",\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\"\r\n  ],\r\n  \"samlMetadataUrl\": null,\r\n  \"servicePrincipalNames\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n    \"f6b5daaa-69aa-4ad0-8c31-0c59b6586f39\"\r\n  ],\r\n  \"servicePrincipalType\": \"Application\",\r\n  \"signInAudience\": \"AzureADMyOrg\",\r\n  \"tags\": [],\r\n  \"tokenEncryptionKeyId\": null\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "1985"
+          "2240"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -699,28 +861,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:37 GMT"
+          "Wed, 27 Jun 2018 18:01:44 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "gzTHd9xPT6UpzqL1VdRsA3bqkd3Ju1OXrLwpKneHrpg="
+          "VRduinh48wLsWX4gv475GCgG1fPJPOTtSGWFaOBDTQM="
         ],
         "request-id": [
-          "51bb5047-8ca2-44c6-8365-bd479001f4b9"
+          "69dd0ca4-5c43-4d39-9f25-f2216f8a975f"
         ],
         "client-request-id": [
-          "f6dc8344-860e-45d4-918c-4516b92d148b"
+          "aa3bf542-157a-4220-b7b3-bd503bd871bb"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "fQ5wNGrepN265RXA8U930xutTRq0K_fEMyuNff2qeWjHbqL4ynJ5bYfxDNmbiAAdRL9HrP5mfyjiHfcKF_ly75nsR5GBPCL2vjuyIyswuZ3oOSx20UxdtzyPd73CBcOPVJyR7jwvyS1MAIrQprOi7qlsmIUnIdUBAPUc0xkkPGM4n_Onm9b0AExIsdT7sSTzzHlNZLj1AI-MdqNmPZs-vQ.bfoIzjXF1n475ws9CeqJHle8ykdO318103m5wNgojtc"
+          "2W_eydCgv69_MH2n3nY6yIMaB1_JrlxK_4lq5gESbCzT8AznDKPpYrp0Rvov3jH4rwupdo6Y4JdOm54MlAQwkZzzvRoHf0Q-cofdshWr2uTwCUM9eUwQBsc40l6AS4FyxlRHPF0y2DXgc7xjmALt9A.1CHxt9lRGwHqVRWi6IwDNPxaRNFekZDd-9mqRUtH8Xw"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -742,33 +904,33 @@
           "ASP.NET"
         ],
         "Duration": [
-          "547933"
+          "677084"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmI/YXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDg/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "e51c89be-63bb-4eb7-aeae-ea7cc547718b"
+          "a7fea1e0-53a9-4da7-86b2-9790591169fa"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.ServicePrincipal\",\r\n  \"objectType\": \"ServicePrincipal\",\r\n  \"objectId\": \"b0c31ede-cb7a-4ca7-b7de-d065e66a342b\",\r\n  \"deletionTimestamp\": null,\r\n  \"accountEnabled\": true,\r\n  \"addIns\": [],\r\n  \"alternativeNames\": [],\r\n  \"appDisplayName\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"appId\": \"ec8b883e-e279-4b37-a29a-8df0f56ac37e\",\r\n  \"appOwnerTenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n  \"appRoleAssignmentRequired\": false,\r\n  \"appRoles\": [],\r\n  \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"errorUrl\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n  \"keyCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-01-11T12:14:37.6976959Z\",\r\n      \"keyId\": \"7e673fa3-cafa-4a1e-95f7-80edaceca44c\",\r\n      \"startDate\": \"2018-01-10T12:14:37.6976959Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ],\r\n  \"logoutUrl\": null,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"id\": \"8073ece8-3069-46c6-9146-322519e2fbb0\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"passwordCredentials\": [],\r\n  \"preferredTokenSigningKeyThumbprint\": null,\r\n  \"publisherName\": \"AzureSDKTeam\",\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\"\r\n  ],\r\n  \"samlMetadataUrl\": null,\r\n  \"servicePrincipalNames\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n    \"ec8b883e-e279-4b37-a29a-8df0f56ac37e\"\r\n  ],\r\n  \"servicePrincipalType\": \"Application\",\r\n  \"tags\": [],\r\n  \"tokenEncryptionKeyId\": null\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal/@Element\",\r\n  \"odata.type\": \"Microsoft.DirectoryServices.ServicePrincipal\",\r\n  \"objectType\": \"ServicePrincipal\",\r\n  \"objectId\": \"9385acae-5eb2-4ea4-9d0d-ff88cd259d48\",\r\n  \"deletionTimestamp\": null,\r\n  \"accountEnabled\": true,\r\n  \"addIns\": [],\r\n  \"alternativeNames\": [],\r\n  \"appDisplayName\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"appId\": \"f6b5daaa-69aa-4ad0-8c31-0c59b6586f39\",\r\n  \"appOwnerTenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n  \"appRoleAssignmentRequired\": false,\r\n  \"appRoles\": [],\r\n  \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"errorUrl\": null,\r\n  \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n  \"keyCredentials\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-06-29T18:01:45.9053922Z\",\r\n      \"keyId\": \"edf1db12-89d7-492f-ae03-f5f92cad082b\",\r\n      \"startDate\": \"2018-06-27T18:01:45.9053922Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    },\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-06-28T18:01:42.7760486Z\",\r\n      \"keyId\": \"8938ad9f-1fb7-4dc1-9920-3cb02519419f\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7760486Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ],\r\n  \"logoutUrl\": null,\r\n  \"oauth2Permissions\": [\r\n    {\r\n      \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on behalf of the signed-in user.\",\r\n      \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"id\": \"9494d843-fb44-4816-a4c8-87c32cfba7b9\",\r\n      \"isEnabled\": true,\r\n      \"type\": \"User\",\r\n      \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on your behalf.\",\r\n      \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"value\": \"user_impersonation\"\r\n    }\r\n  ],\r\n  \"passwordCredentials\": [],\r\n  \"preferredTokenSigningKeyThumbprint\": null,\r\n  \"publisherName\": \"AzureSDKTeam\",\r\n  \"replyUrls\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\"\r\n  ],\r\n  \"samlMetadataUrl\": null,\r\n  \"servicePrincipalNames\": [\r\n    \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n    \"f6b5daaa-69aa-4ad0-8c31-0c59b6586f39\"\r\n  ],\r\n  \"servicePrincipalType\": \"Application\",\r\n  \"signInAudience\": \"AzureADMyOrg\",\r\n  \"tags\": [],\r\n  \"tokenEncryptionKeyId\": null\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "2030"
+          "2286"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -780,28 +942,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:38 GMT"
+          "Wed, 27 Jun 2018 18:01:45 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "K7+AvfaamY7DwcxlbHLJ+P0optdxEzfgDUCXy1QyENk="
+          "VRduinh48wLsWX4gv475GCgG1fPJPOTtSGWFaOBDTQM="
         ],
         "request-id": [
-          "4ff237f0-0e5b-43c3-8a34-a50bd4aaf143"
+          "8e6be4f0-342d-491a-a2d7-eb0444d9dded"
         ],
         "client-request-id": [
-          "6e201b48-e7b8-458d-9fac-1f83968b2143"
+          "828c6cbd-f913-4962-92f8-45a03e759263"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "ILEeUWQIqWe-Gre7TOG6mHXlarJHBvoMa28h8mtYgvtk8J6Cbhvr9cUzzV2HPmK4PexktJAqIwvO3gVG4_IBFwCnAMv2Ge1JzN3r4JcKNWL-h0LUr5iteQlrqWNVwFRAXcjW0p2OY9dtXPGpcFNiZH2gvnx_36Ewa7IzQdkRoAO8QFDUmSWKbfVxe89UXIelSzGJ_xx-hweUb2vYZq-g5A.LXyC0iiqn5dL1ZU49fa5gSNTC-INWo2L9TPZlGFmWus"
+          "yOUc6QPA3h_BUSGDIFsgs07esmau5P_C4ealVUwbc6YLIH5usNRtUn6E93DIjPyZoqjgDt2Mdnnpp5O3PnCt1IQGD-fQll2n2T3x9nlpb-e0Dzd5w0dsTa4KkgaiP-0UAB-OC0pGvh2_ZWOsPX5c5g.n3BtIBE7OfR9eQdBYJ4mnKyBvShQAqsyJsWVSyhrZdM"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -823,273 +985,30 @@
           "ASP.NET"
         ],
         "Duration": [
-          "587809"
+          "529392"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/keyCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/keyCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "33028980-5f61-42f3-b124-4db5e1566c16"
+          "058826e5-140e-46ea-bb3c-84cde10bcfd4"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": []\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "158"
-        ],
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 10 Jan 2018 12:14:37 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "ocp-aad-diagnostics-server-name": [
-          "fZDW4qmLV9JXj3cogZcj4KUdsgN2NyKPG/qO9606ABg="
-        ],
-        "request-id": [
-          "0a28e9db-2d78-4828-aca6-424c50836a2d"
-        ],
-        "client-request-id": [
-          "8cc0044d-f9d0-4331-a85a-c410269b8486"
-        ],
-        "x-ms-dirapi-data-contract-version": [
-          "1.6"
-        ],
-        "ocp-aad-session-key": [
-          "61P6aBE61oj3HNCdujgm5g6Oo8VQ_4pZByKIq1P8kaYbW21ZHKs2pSFZ0nzCmc8pGbgoFR3LNI7lSADWZmek_1BD7AsmFH6ZDWhgxxBzmR2_PpEf_My9mOTzo2dTV5EztZKllgbhLPQGjutVsGyjfzHIDCNiYkIRY9jfFfhjfK1lWOBSByGBFee1wTB5a3fVs_Fb0wZWORhFtmbVZ92aIA.axkjEZt8CyXeThmXRP8s7oSIziHsoqXt7nqhu5kkiTU"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Access-Control-Allow-Origin": [
-          "*"
-        ],
-        "X-AspNet-Version": [
-          "4.0.30319"
-        ],
-        "X-Powered-By": [
-          "ASP.NET",
-          "ASP.NET"
-        ],
-        "Duration": [
-          "569901"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/keyCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "ae4b6a44-fba3-44c8-85e0-8217a92fbc5f"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": []\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "158"
-        ],
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 10 Jan 2018 12:14:37 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "ocp-aad-diagnostics-server-name": [
-          "fZDW4qmLV9JXj3cogZcj4KUdsgN2NyKPG/qO9606ABg="
-        ],
-        "request-id": [
-          "6ee402d9-c641-4c31-a989-9399ee79d982"
-        ],
-        "client-request-id": [
-          "b97e6b11-c106-4261-9561-974feac5deb5"
-        ],
-        "x-ms-dirapi-data-contract-version": [
-          "1.6"
-        ],
-        "ocp-aad-session-key": [
-          "C8gSddlLi63-vDGoxwG9w39AhYy0D8iSqQfoF84REkwdL_0AAYdgNaIxbTSSC9QpWs1UfLThWMFG_SLz94mc0pY7CAChOKg0BgJESarm_049VIi3hW925hjwpUVpJoy2OT5_hxjGZFC3agDYZbrAzhZH7sBsSGt5A6-_kL2aut82y7d7ziGP6HZFL7xYqXGMkKNfioxGmjLCPVr9A9_j6w.zFcQ5ZyiIv_cAlwAR2eWim4thbVuKCA4pGsaEiduIHg"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Access-Control-Allow-Origin": [
-          "*"
-        ],
-        "X-AspNet-Version": [
-          "4.0.30319"
-        ],
-        "X-Powered-By": [
-          "ASP.NET",
-          "ASP.NET"
-        ],
-        "Duration": [
-          "567574"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/keyCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "c61b880c-95e8-43ea-aea9-4e4e12f2fdf9"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": []\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "158"
-        ],
-        "Content-Type": [
-          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 10 Jan 2018 12:14:37 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "ocp-aad-diagnostics-server-name": [
-          "K7+AvfaamY7DwcxlbHLJ+P0optdxEzfgDUCXy1QyENk="
-        ],
-        "request-id": [
-          "e29f71d9-492d-4f52-8b27-8d21865861b2"
-        ],
-        "client-request-id": [
-          "71fc92b9-7e73-4d4b-9141-8c32e63ea233"
-        ],
-        "x-ms-dirapi-data-contract-version": [
-          "1.6"
-        ],
-        "ocp-aad-session-key": [
-          "8IodlzaiaP9aPajCojXTosfaoaelonknXNs-zDjumW2MoWTYwaKx6L1eOyAGrxscf5RImhdsNoIfavpLgarogm7M_sv214R_yE7I4fd5RDaB2V6M1KpsJL7D0kGOjmh5ERS81tW19MeHB6Oio-OE-ULF0YUUvObHCTW_CDwl87iFxOqun5PaT4wJtqo2XnFcOJC9PwFiVawogwfkDKQXOg.f8zpVhJM-19yUf3uQBKL3HwZNe-i5NWTSfPMCAbfzfQ"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "3.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Access-Control-Allow-Origin": [
-          "*"
-        ],
-        "X-AspNet-Version": [
-          "4.0.30319"
-        ],
-        "X-Powered-By": [
-          "ASP.NET",
-          "ASP.NET"
-        ],
-        "Duration": [
-          "527837"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/keyCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "0b2ed4a9-2445-4779-8419-6d19b5ba3aea"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-01-11T12:14:37.6976959Z\",\r\n      \"keyId\": \"7e673fa3-cafa-4a1e-95f7-80edaceca44c\",\r\n      \"startDate\": \"2018-01-10T12:14:37.6976959Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-06-28T18:01:42.7760486Z\",\r\n      \"keyId\": \"8938ad9f-1fb7-4dc1-9920-3cb02519419f\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7760486Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "381"
@@ -1104,28 +1023,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:38 GMT"
+          "Wed, 27 Jun 2018 18:01:44 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "X7JJrDJZ6J5u3UjAG6S964BeoRqIrZ+Y1/baVMmjI9U="
+          "aLjul60AojNkmrHXU2K8UCWjsiSBDyBxA+NSaz2RTqQ="
         ],
         "request-id": [
-          "1b120021-c473-4dce-9d82-45dcd1116976"
+          "ed6cbd2a-9455-4c8f-8d75-937189fefcda"
         ],
         "client-request-id": [
-          "1d7901e0-b331-4241-812f-99b09daccdb4"
+          "fc5bb919-582d-4dab-b680-ebd82c00b717"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "oISToNo0GkAOxIzmaqs_suQLClI7obsXQ1FayV_u4L4D9wfVcKsl5YJjKngRqCcmGk8RH56TEvAkdI9tDSZWJsg3DKkuHnvdRECYB5LHa1BbpqglRmMEVFujH1tIDdhHrLvYXciQp_OGbysxD8U49tMPScboy8P1DM19Wawim6rQ-Prfd66GyuTN8j39Y8YiwzkVUZLapNI4yTy8xfubZg.MJ-RaejLfD34TLrd1OHLYXd6RFXFFk5B7zJyuTRgKS4"
+          "jqDKxMHnF2YG9o_nt8ig2hMfzJlXULkfrHpz2MQWh2SL1StTcIQieBr040rr_pnuZT7W9sO9Xj72H-J8_0avYlZIG-gmRmoCXGhEOG801Vaqvh6CBFCPJkjOpSxzZ98YNrwao-jmG0sydCsVWdTM-Q.tvJC0rgu1CEHvQ0BNyv6kWYuIDP4VCYoMpmwGzccIf8"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1147,30 +1066,30 @@
           "ASP.NET"
         ],
         "Duration": [
-          "949250"
+          "571187"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/keyCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/keyCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "f91f2955-2c70-4305-9fef-b16a0b5d32db"
+          "d3ce54fb-bc60-459a-a148-7a2de7cfa767"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-01-11T12:14:37.6976959Z\",\r\n      \"keyId\": \"7e673fa3-cafa-4a1e-95f7-80edaceca44c\",\r\n      \"startDate\": \"2018-01-10T12:14:37.6976959Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-06-28T18:01:42.7760486Z\",\r\n      \"keyId\": \"8938ad9f-1fb7-4dc1-9920-3cb02519419f\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7760486Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "381"
@@ -1185,28 +1104,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:39 GMT"
+          "Wed, 27 Jun 2018 18:01:44 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "EmAW/3cq3T9S4P42xbgMBExuBExGKCe4J4aWuRotPBI="
+          "WWe9QgsvUicjoyAoKn+dEp/jx1mlcMwTYk2lly59ESw="
         ],
         "request-id": [
-          "15277f7b-e937-4be4-bb65-aaf504291c2e"
+          "d0716414-70b1-4a33-a269-c1872fccb87c"
         ],
         "client-request-id": [
-          "888367d0-6f77-40a5-8575-93ce207f2b59"
+          "ffed55fd-79dd-4c5c-bd9d-fb1d078ee95b"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "MWXyNUysu63Em1nNQ4ODoew3AGGpKMPX2tHn4cMqhzyDfwf9Kjyz4Y8iwqs5XUBnDoHvYq-zGggwfMS5QivkO_RtyT9tF_sC9_4A_S9T7LWzHtQq0nVrqproEdrBPIkvGeWN0n77jtwAaMPkFu_JEuuXikPEFT5VyXLsjuwkKquCcp9VajLi0ohwzi2OG58kvPQULovR3Ye9y8cPUD7Ueg.hgwKjwqBnMiWVmXoRU42FkG0NEsMa2w3koaMmUynb2E"
+          "soMO69NwUFAS75IpgfU7fr9sCPlo0LUQXQYh7yRje-WWja4GftIM3W9jns_fyggDurg_NqgBrK6OP6mhd6oIroafbnxHnI-GRunjfPGijRb0RwDJcNeaMuYw51kkqY9_A14jH0IdNaRIR304ztpyiA.2R9cp0ys-UxAeW2lao7PxMxqGyN9KX9FC66E8VrDi1o"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1228,30 +1147,273 @@
           "ASP.NET"
         ],
         "Duration": [
-          "701139"
+          "494154"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/passwordCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/keyCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "6f309956-caf1-4b77-a388-c03cb3790cbc"
+          "76daad9c-6068-482f-891d-1af6c5b2b920"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BwYXNz\",\r\n      \"endDate\": \"2019-01-10T12:14:34.9270661Z\",\r\n      \"keyId\": \"435ad9c7-a501-4921-b6bc-ecc0cf4f6597\",\r\n      \"startDate\": \"2018-01-10T12:14:34.9270661Z\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-06-28T18:01:42.7760486Z\",\r\n      \"keyId\": \"8938ad9f-1fb7-4dc1-9920-3cb02519419f\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7760486Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "381"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 27 Jun 2018 18:01:44 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
+        "ocp-aad-diagnostics-server-name": [
+          "R7GE/wZDw5mYOVlPUsy4LuVepndfwrdQz1ATlcVdHv4="
+        ],
+        "request-id": [
+          "f518f261-15f2-48dd-b26d-74818322e53e"
+        ],
+        "client-request-id": [
+          "1eeda7c8-5bd4-4ab4-9694-957b24398c18"
+        ],
+        "x-ms-dirapi-data-contract-version": [
+          "1.6"
+        ],
+        "ocp-aad-session-key": [
+          "9ZV8SzweiuSB9C-A7RQRFIJLcc_BXBQQTD9ODAfcwBPVVPJ0Zoc-hc4ypyxsCBL6nMD9t3_aqLwNgZIszl9MwjgDu8z6U0tDoSkMpecCSQ0MKgfFO3ETx9gcOcw1DEth-y68tzQ6tmVKKQx_6MXJkg.r2ZG2LryCIUGBF7FExiEU7G5ZeI8ubniLraHSCq6uuM"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Access-Control-Allow-Origin": [
+          "*"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "X-Powered-By": [
+          "ASP.NET",
+          "ASP.NET"
+        ],
+        "Duration": [
+          "561735"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/keyCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "c3f857e7-3b69-47ff-aa08-3729d7d21ae9"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-06-29T18:01:45.9053922Z\",\r\n      \"keyId\": \"edf1db12-89d7-492f-ae03-f5f92cad082b\",\r\n      \"startDate\": \"2018-06-27T18:01:45.9053922Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    },\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-06-28T18:01:42.7760486Z\",\r\n      \"keyId\": \"8938ad9f-1fb7-4dc1-9920-3cb02519419f\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7760486Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "605"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 27 Jun 2018 18:01:45 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
+        "ocp-aad-diagnostics-server-name": [
+          "XOs9gGfyH50gS8B3zPgeXNS3pfhaVVLdmqEFzm9FoHE="
+        ],
+        "request-id": [
+          "e30e0592-426f-4673-b30b-a0c79d827ddd"
+        ],
+        "client-request-id": [
+          "480cbb23-2321-4996-815c-1cc42b1f6995"
+        ],
+        "x-ms-dirapi-data-contract-version": [
+          "1.6"
+        ],
+        "ocp-aad-session-key": [
+          "djOepsfR91eEyUXNP2zIKbgFi3UbuBTygeNjX8PS-BbnpZozwPgHw0wRKdM6WQcxdeQduBI-iDm2M3jVm7uoO69YYfRO5wqvSFNiCexIkHW7JaJfniuku2MkU2YjKNk3t3t7ubv9VrFfff4U6rS3gw.p-SrjNp9PzRR6LLtRt00ce7n3V23aoiQHu3tANRFMEE"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Access-Control-Allow-Origin": [
+          "*"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "X-Powered-By": [
+          "ASP.NET",
+          "ASP.NET"
+        ],
+        "Duration": [
+          "670579"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/keyCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "4c31ec79-4e2f-4d5c-90ad-5a11592917cd"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.KeyCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-06-29T18:01:45.9053922Z\",\r\n      \"keyId\": \"edf1db12-89d7-492f-ae03-f5f92cad082b\",\r\n      \"startDate\": \"2018-06-27T18:01:45.9053922Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    },\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"endDate\": \"2018-06-28T18:01:42.7760486Z\",\r\n      \"keyId\": \"8938ad9f-1fb7-4dc1-9920-3cb02519419f\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7760486Z\",\r\n      \"type\": \"AsymmetricX509Cert\",\r\n      \"usage\": \"Verify\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "605"
+        ],
+        "Content-Type": [
+          "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 27 Jun 2018 18:01:45 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
+        "ocp-aad-diagnostics-server-name": [
+          "R7GE/wZDw5mYOVlPUsy4LuVepndfwrdQz1ATlcVdHv4="
+        ],
+        "request-id": [
+          "6510bc63-6c62-4c14-af1a-ec2239a0d728"
+        ],
+        "client-request-id": [
+          "7b60c796-aa9f-4a96-9136-2af20e888d9a"
+        ],
+        "x-ms-dirapi-data-contract-version": [
+          "1.6"
+        ],
+        "ocp-aad-session-key": [
+          "KBRm8brjeEpBoF4SSbQOuclp0pxCNRyW_zszrSKL0VIBHVzw37UpUjXTjyYU4k9WcgiaYWHwui7Nj8dCQmjRQ9J7k_4ooy1UBQMp-KzhCWFucyKN9KmQx4urHDoX3BRkqFUXXtyPdof39fRiT00i5g.wXgrqF9aFeQMRyVvQ0PP8V_9biC9Fx2DjIjWqY2NV54"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "DataServiceVersion": [
+          "3.0;"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Access-Control-Allow-Origin": [
+          "*"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "X-Powered-By": [
+          "ASP.NET",
+          "ASP.NET"
+        ],
+        "Duration": [
+          "445323"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/passwordCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "2bb81de5-c7c3-4bbc-979c-1c497379a7bb"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BwYXNz\",\r\n      \"endDate\": \"2019-06-27T18:01:42.7730739Z\",\r\n      \"keyId\": \"c21175fa-810b-4e71-958a-e333ea0b28fc\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7730739Z\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "341"
@@ -1266,28 +1428,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:37 GMT"
+          "Wed, 27 Jun 2018 18:01:44 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "gzTHd9xPT6UpzqL1VdRsA3bqkd3Ju1OXrLwpKneHrpg="
+          "0sfE/ORXQruXagUwgN6LKCMJnfSNsPKIg39HCVmIqe8="
         ],
         "request-id": [
-          "cd22e936-4a7d-4791-83fe-9601ef0b88fd"
+          "9f795db5-e6c0-4dcf-9be5-e9364f1d549f"
         ],
         "client-request-id": [
-          "aae17f02-72f4-4ef6-a340-d70f8f57cb27"
+          "006a65bf-2ce6-4aa9-bf29-bef1c3fc9199"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "xafOAMoylAmS7SnXFASyTkkcYLeaGR3inXqcJVbdmPltNcWu9hIqs7uQgC3afC4ObrtioYOZS-RAjvOAneKUmzmUYFlkddTFz-KxUWgHsIRn3IuiSRRQYRiZ5yLiXzKSaQDP8OGCYSbtg63Hl4FBRjl0IB79yYdj3WV7-4aF-kq5jO4M8eyLO8vTYAQaKI8s63dsV-7xyLg52WWoI9VsGg.d_99z4OFXngqBwSsslm0mdcqKIwtu2wXN4BW-h8eYNA"
+          "0Px53CZMsLDm2CzEYUsowSpGKYj1LWl1hImzdF2aZJvvBR3GYvKYzAS2P0a2IypCtsZ55AhVxe9fFGi5RP99tUHN5TqyaObpMQCR_s4FJacK7-4-tobOEoj7BMqjNgJTRWfsJrlpEwSyM5ocIi0vRA.AfGYZ4bEiZgOSeW9oNUCcYFZuo4hFc_Hbp1Tk1JKDRQ"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1309,30 +1471,30 @@
           "ASP.NET"
         ],
         "Duration": [
-          "557777"
+          "470043"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/passwordCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/passwordCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "5002d2ef-275c-492b-8b35-62bf8652d1be"
+          "89455440-d07d-40a3-b030-c7e414bdaff2"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BwYXNz\",\r\n      \"endDate\": \"2019-01-10T12:14:34.9270661Z\",\r\n      \"keyId\": \"435ad9c7-a501-4921-b6bc-ecc0cf4f6597\",\r\n      \"startDate\": \"2018-01-10T12:14:34.9270661Z\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BwYXNz\",\r\n      \"endDate\": \"2019-06-27T18:01:42.7730739Z\",\r\n      \"keyId\": \"c21175fa-810b-4e71-958a-e333ea0b28fc\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7730739Z\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "341"
@@ -1347,28 +1509,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:37 GMT"
+          "Wed, 27 Jun 2018 18:01:44 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "K7+AvfaamY7DwcxlbHLJ+P0optdxEzfgDUCXy1QyENk="
+          "VRduinh48wLsWX4gv475GCgG1fPJPOTtSGWFaOBDTQM="
         ],
         "request-id": [
-          "c69ce7f2-a54e-4d71-9034-b5a90ae7ab7d"
+          "601b6096-6660-4a1a-9396-f32604ec7ada"
         ],
         "client-request-id": [
-          "a1f88fcc-7cb2-4611-a022-c83dfa238773"
+          "33d7c793-56a2-46d7-b796-d60556776df6"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "L0jvDurQsI1jbmkjZZfbF6TR7LaieFeR2WrmWS7eU5ToovZu7gICRTbP-g4NppubY0NA30SvNKzrU-yTPb-IOF2ykCpASMowA6cUqdwwwtxaAb1uYXoLgYRjP0YxxWCpDTiCpUawVt5EbyDQnOVOx1rZF6jyKD0JfquLL8-_HsXhLYTVJGXu4K8Dv5XyPGSAaYfCzzqAxPoU-OfUUv3pHQ.Iddcg9ZNbsPxzRN0vswiD4C-6iUQduYswSYEaoQSNEI"
+          "b62TexnHhwSas3cA9jvhbqbM7yMyMyaO-3oGd-Nqk3v7IUDVYKI4uP9wuB4BHpDnrrzyioa1_9bzFuOYyB7RVezxbZJZdQqh3Quypehj2Hp79Yo3h2PMS3u11lXwIVEgW12ZLRm-N3aiFggfNLkq3Q.NFoNkeyUd6Av90ruSaNoP-4x-YKIckjH8fv_FVGGfbw"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1390,30 +1552,30 @@
           "ASP.NET"
         ],
         "Duration": [
-          "594487"
+          "443332"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/passwordCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/passwordCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "4553c3d8-691d-42fa-8c05-706b400aa347"
+          "1b5ca43d-e975-4504-be76-2e13ce56f8c4"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BwYXNz\",\r\n      \"endDate\": \"2019-01-10T12:14:34.9270661Z\",\r\n      \"keyId\": \"435ad9c7-a501-4921-b6bc-ecc0cf4f6597\",\r\n      \"startDate\": \"2018-01-10T12:14:34.9270661Z\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BwYXNz\",\r\n      \"endDate\": \"2019-06-27T18:01:42.7730739Z\",\r\n      \"keyId\": \"c21175fa-810b-4e71-958a-e333ea0b28fc\",\r\n      \"startDate\": \"2018-06-27T18:01:42.7730739Z\",\r\n      \"value\": null\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "341"
@@ -1428,28 +1590,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:37 GMT"
+          "Wed, 27 Jun 2018 18:01:44 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "gzTHd9xPT6UpzqL1VdRsA3bqkd3Ju1OXrLwpKneHrpg="
+          "R7GE/wZDw5mYOVlPUsy4LuVepndfwrdQz1ATlcVdHv4="
         ],
         "request-id": [
-          "48a0526f-7fff-4a50-af16-b768bd9a1eb6"
+          "6a75b7b8-30e4-46bd-b2e2-82bd68e1a3ea"
         ],
         "client-request-id": [
-          "c79d6299-2d4c-43ad-9fec-9cbc86d851ef"
+          "b795751f-55f7-4491-84f4-55f5b101a673"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "rXkebonV4ij3AiLQsr8-xhsPzbp9doegrwbZlr8get31lx9FiOQr36eahcJ2uFs1F-tGvzHrBX1vxEcUaESwBSN06WJajAlPuWzr2p9qX_mVekrHkzyq6fU1PzL0Rx8ymVgrgSCRls6oikjuHTwXFB7qOqsi5NBXTzKKDMO0G3uR0kRZGv6Et75-VkMXb3auP_nZWc3QzEmTCetAw1LBag.vTEkgzBJ-7ykRDg1dXcJVniuU3Jqk9b63iL9qH8p7rM"
+          "0JxKSnt-lqnXEEMqfYtvldKp5mGNdhxS7Pgf3flIgYYfhjvT764jAPVaS82Q2lY5LFpuC1FK88-PT5jVYa3rymdTNZsqSB3pAxd969e16TDFcJ-dHijbIyJY5XOyuJ75wwCmw81riIh_gwb5BTc8_w.IpZm887BZ7Lo4EDkLVyslyVpAXg2Yae0yzh1REZk9h4"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1471,27 +1633,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "557228"
+          "951177"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/passwordCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/passwordCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "cd97c332-cb0a-4a0c-98fe-cb05954731b6"
+          "aa8a7235-bae8-4b67-bf97-8a866292df18"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": []\r\n}",
@@ -1509,28 +1671,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:39 GMT"
+          "Wed, 27 Jun 2018 18:01:45 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "iaSFgYC+tqsHdxf0PYhhSBaccCVQl9a2v/hX0IE9E2Q="
+          "Fo1QicrIhHj2KR1ZzWvNa2KLRHgOjpt7/hmcNDActAs="
         ],
         "request-id": [
-          "8c141268-5077-41a2-86b4-745b29c711f9"
+          "194ccb92-ae52-47f2-8b9f-39936a033417"
         ],
         "client-request-id": [
-          "6ce6d6f7-010e-4fbf-bdd5-13ca08a474a4"
+          "34139201-c6a1-47c3-a3b1-a617e447846c"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "6ShRUfIejnYF4lmw6r1u4gCNG6rwxmdZuiUtwX7JVMlg-RDoYcAV5QXf9cEukSHeYX2ODuu76fF8KvreDPZsiQuNcKORhD_d6ycOxXbShXmpDhzVYTgDUmGVgbXD_9jucuXqugfJhcN0R-BBEVT6PTvjEYo_HhE4cecSw14ALbrQSdYwVHQjIYKkjRqRxWiTyLr1kJ3C9u36ChAKRzVkFA.rZdf7vELc7ETuaYUKywpvdVaDTWMHmyUVE8na5ZxP-E"
+          "AjIGEfCGPBnF0FJ5poEbuaplV82kwZDyfHvMnLR4KaC3fUkiJm_kA4h-tcvIwaaOLivik_sBAQ56dizMogZCRktUi2iQe3CYyfx7U4rpCk_q9qn_IXwb5Kkh0bWzslMARpE33FP9R8a3G8JfFKDBQQ.rnV9Nf8C6i-vHux5GQY8_qNTDK2dXAWsLK91cUsdemc"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1552,27 +1714,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "1976351"
+          "716674"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/passwordCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48/passwordCredentials?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDgvcGFzc3dvcmRDcmVkZW50aWFscz9hcGktdmVyc2lvbj0xLjY=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "7a9a61c4-38cb-4049-8256-f0b00359a217"
+          "e360425d-05ed-4bcc-bedc-b3110014fd31"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#Collection(Microsoft.DirectoryServices.PasswordCredential)\",\r\n  \"value\": []\r\n}",
@@ -1590,28 +1752,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:39 GMT"
+          "Wed, 27 Jun 2018 18:01:45 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "gzTHd9xPT6UpzqL1VdRsA3bqkd3Ju1OXrLwpKneHrpg="
+          "R7GE/wZDw5mYOVlPUsy4LuVepndfwrdQz1ATlcVdHv4="
         ],
         "request-id": [
-          "7af40442-faaf-4fb3-bd8d-b8afb872d1f3"
+          "923c8375-245f-4f00-934a-cbe7fe96481f"
         ],
         "client-request-id": [
-          "91e06333-6e39-4f6c-921b-058f2e0b5549"
+          "e175793a-e51d-438c-a483-cdb10049d27c"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "ZSugVISoEjev25pDY62s9QecV8LK3lzwuPMkF0gqfG0QIk4P6yECzGSHgAjlRbTVVBqm0YLWhX0bNMpne15tYMji2_yVrU_Q4Vb6uy4A9VFwtBbmi3xfqzI-renEFQ-_C8Jouy37tkCr99NCafKc4BRey-KrACc7DSzK9KyKOhqnJQjEFfQ0zRFrxZvt2aKOxJfCyz78MkQIbDy2ivkaGA.x_Ke--vBb9-KhLxC8Dx0z9bq4w5r1o4VLZQs6Nq0hwY"
+          "rQPv3W8E0pTUheeIRVfyQc1G0jTV480YcLQ2WhTpx-jQTqepJtwtHu6smDFjTD9tak8bvDrSnOQcGkoL5Ik0GruiO2Z2TPJc6zMXvJnihlVa430ZhDhaz6vIDy9kHEFigdv63v4ZcVocWQu_eSTyog.CepkeE_U4SEL8B9nS2jMj9FhKyAsmziKOgv8qAxsOJk"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1633,27 +1795,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "3242865"
+          "474017"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals?$filter=displayName%20eq%20'ec8b883e-e279-4b37-a29a-8df0f56ac37e'&api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscz8kZmlsdGVyPWRpc3BsYXlOYW1lJTIwZXElMjAnZWM4Yjg4M2UtZTI3OS00YjM3LWEyOWEtOGRmMGY1NmFjMzdlJyZhcGktdmVyc2lvbj0xLjY=",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals?$filter=displayName%20eq%20'f6b5daaa-69aa-4ad0-8c31-0c59b6586f39'&api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscz8kZmlsdGVyPWRpc3BsYXlOYW1lJTIwZXElMjAnZjZiNWRhYWEtNjlhYS00YWQwLThjMzEtMGM1OWI2NTg2ZjM5JyZhcGktdmVyc2lvbj0xLjY=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "56885335-40d6-4b70-9162-d30768e38af2"
+          "ec24a93e-c4fe-4b7a-9160-e895939ac3c7"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal\",\r\n  \"value\": []\r\n}",
@@ -1671,28 +1833,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:37 GMT"
+          "Wed, 27 Jun 2018 18:01:44 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "K7+AvfaamY7DwcxlbHLJ+P0optdxEzfgDUCXy1QyENk="
+          "Fo1QicrIhHj2KR1ZzWvNa2KLRHgOjpt7/hmcNDActAs="
         ],
         "request-id": [
-          "38427c7d-1872-4948-bb94-30038e8ed45d"
+          "af8cf56e-91fd-406f-b7b5-337597bef9a9"
         ],
         "client-request-id": [
-          "ce512e61-2878-44b2-a5ec-6b5cae52cee9"
+          "6234306c-e264-4675-914a-3fc54f6d2bcc"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "BqxF9pOShB0FGsGtfdKlGiwhYlygR-msN3Q7ROds4R19ivEtOn3Pmhu9HSb9N8DfbAHdnNDX5a0ZgqXKUTGFbbcP6jr5NGf3RTzBlojCCq8uiAmA8_gjb8AuaP7VmvXMCkfZtQTzY4avn0CUUoobHDnoPJX_Jyh5109s6vwL6x7NHH_NPS5bXnmQRMoCJdROW9Pyk6DvxoUKSyeldlAjOg.WRCERxKy8nkUJR0rke_EY7hnU3oN8jXtwiIPWiGzOFs"
+          "RHlreAlqUjpGXGTVk3pfeWMre8875tU7Ru9zhO5rtjQb8Pyk2va7tFpQMJaI1C4vldSbKtKn-2WijCSEOmn4_upvNos6UjgXWVmH-58IC7MAaPDvMLKXAZpU3frPvwQE9iiEzZ6khAMoPVWF_QhH6Q.pusUxOmoOIofHpgoRsM79iGZVbfJcmE6e1WGXnaYaQ4"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1714,33 +1876,33 @@
           "ASP.NET"
         ],
         "Duration": [
-          "550226"
+          "454763"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals?$filter=servicePrincipalNames/any(c:c%20eq%20'ec8b883e-e279-4b37-a29a-8df0f56ac37e')&api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscz8kZmlsdGVyPXNlcnZpY2VQcmluY2lwYWxOYW1lcy9hbnkoYzpjJTIwZXElMjAnZWM4Yjg4M2UtZTI3OS00YjM3LWEyOWEtOGRmMGY1NmFjMzdlJykmYXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals?$filter=servicePrincipalNames/any(c:c%20eq%20'f6b5daaa-69aa-4ad0-8c31-0c59b6586f39')&api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscz8kZmlsdGVyPXNlcnZpY2VQcmluY2lwYWxOYW1lcy9hbnkoYzpjJTIwZXElMjAnZjZiNWRhYWEtNjlhYS00YWQwLThjMzEtMGM1OWI2NTg2ZjM5JykmYXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "be057c70-af0e-4c82-8d6c-05a80113285f"
+          "afb2ed69-542b-4c91-b8d1-f25344808e02"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal\",\r\n  \"value\": [\r\n    {\r\n      \"odata.type\": \"Microsoft.DirectoryServices.ServicePrincipal\",\r\n      \"objectType\": \"ServicePrincipal\",\r\n      \"objectId\": \"b0c31ede-cb7a-4ca7-b7de-d065e66a342b\",\r\n      \"deletionTimestamp\": null,\r\n      \"accountEnabled\": true,\r\n      \"addIns\": [],\r\n      \"alternativeNames\": [],\r\n      \"appDisplayName\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"appId\": \"ec8b883e-e279-4b37-a29a-8df0f56ac37e\",\r\n      \"appOwnerTenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n      \"appRoleAssignmentRequired\": false,\r\n      \"appRoles\": [],\r\n      \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"errorUrl\": null,\r\n      \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"keyCredentials\": [],\r\n      \"logoutUrl\": null,\r\n      \"oauth2Permissions\": [\r\n        {\r\n          \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on behalf of the signed-in user.\",\r\n          \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n          \"id\": \"8073ece8-3069-46c6-9146-322519e2fbb0\",\r\n          \"isEnabled\": true,\r\n          \"type\": \"User\",\r\n          \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on your behalf.\",\r\n          \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n          \"value\": \"user_impersonation\"\r\n        }\r\n      ],\r\n      \"passwordCredentials\": [\r\n        {\r\n          \"customKeyIdentifier\": \"c3BwYXNz\",\r\n          \"endDate\": \"2019-01-10T12:14:34.9270661Z\",\r\n          \"keyId\": \"435ad9c7-a501-4921-b6bc-ecc0cf4f6597\",\r\n          \"startDate\": \"2018-01-10T12:14:34.9270661Z\",\r\n          \"value\": null\r\n        }\r\n      ],\r\n      \"preferredTokenSigningKeyThumbprint\": null,\r\n      \"publisherName\": \"AzureSDKTeam\",\r\n      \"replyUrls\": [\r\n        \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\"\r\n      ],\r\n      \"samlMetadataUrl\": null,\r\n      \"servicePrincipalNames\": [\r\n        \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n        \"ec8b883e-e279-4b37-a29a-8df0f56ac37e\"\r\n      ],\r\n      \"servicePrincipalType\": \"Application\",\r\n      \"tags\": [],\r\n      \"tokenEncryptionKeyId\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.ServicePrincipal\",\r\n  \"value\": [\r\n    {\r\n      \"odata.type\": \"Microsoft.DirectoryServices.ServicePrincipal\",\r\n      \"objectType\": \"ServicePrincipal\",\r\n      \"objectId\": \"9385acae-5eb2-4ea4-9d0d-ff88cd259d48\",\r\n      \"deletionTimestamp\": null,\r\n      \"accountEnabled\": true,\r\n      \"addIns\": [],\r\n      \"alternativeNames\": [],\r\n      \"appDisplayName\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"appId\": \"f6b5daaa-69aa-4ad0-8c31-0c59b6586f39\",\r\n      \"appOwnerTenantId\": \"54826b22-38d6-4fb2-bad9-b7b93a3e9c5a\",\r\n      \"appRoleAssignmentRequired\": false,\r\n      \"appRoles\": [],\r\n      \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"errorUrl\": null,\r\n      \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"keyCredentials\": [\r\n        {\r\n          \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n          \"endDate\": \"2018-06-28T18:01:42.7760486Z\",\r\n          \"keyId\": \"8938ad9f-1fb7-4dc1-9920-3cb02519419f\",\r\n          \"startDate\": \"2018-06-27T18:01:42.7760486Z\",\r\n          \"type\": \"AsymmetricX509Cert\",\r\n          \"usage\": \"Verify\",\r\n          \"value\": null\r\n        }\r\n      ],\r\n      \"logoutUrl\": null,\r\n      \"oauth2Permissions\": [\r\n        {\r\n          \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on behalf of the signed-in user.\",\r\n          \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n          \"id\": \"9494d843-fb44-4816-a4c8-87c32cfba7b9\",\r\n          \"isEnabled\": true,\r\n          \"type\": \"User\",\r\n          \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on your behalf.\",\r\n          \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n          \"value\": \"user_impersonation\"\r\n        }\r\n      ],\r\n      \"passwordCredentials\": [\r\n        {\r\n          \"customKeyIdentifier\": \"c3BwYXNz\",\r\n          \"endDate\": \"2019-06-27T18:01:42.7730739Z\",\r\n          \"keyId\": \"c21175fa-810b-4e71-958a-e333ea0b28fc\",\r\n          \"startDate\": \"2018-06-27T18:01:42.7730739Z\",\r\n          \"value\": null\r\n        }\r\n      ],\r\n      \"preferredTokenSigningKeyThumbprint\": null,\r\n      \"publisherName\": \"AzureSDKTeam\",\r\n      \"replyUrls\": [\r\n        \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\"\r\n      ],\r\n      \"samlMetadataUrl\": null,\r\n      \"servicePrincipalNames\": [\r\n        \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n        \"f6b5daaa-69aa-4ad0-8c31-0c59b6586f39\"\r\n      ],\r\n      \"servicePrincipalType\": \"Application\",\r\n      \"signInAudience\": \"AzureADMyOrg\",\r\n      \"tags\": [],\r\n      \"tokenEncryptionKeyId\": null\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "1988"
+          "2243"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -1752,28 +1914,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:37 GMT"
+          "Wed, 27 Jun 2018 18:01:44 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "K7+AvfaamY7DwcxlbHLJ+P0optdxEzfgDUCXy1QyENk="
+          "UJod7VmkPiqRZ3LL8q1JqdoyPpXCav9KRxab7im3lsM="
         ],
         "request-id": [
-          "ce314463-0a69-4b66-a01f-726488d27fcd"
+          "51afa5fd-0f87-450a-8706-93f275ce0d21"
         ],
         "client-request-id": [
-          "a79a6296-327c-499a-926f-4e07e5e8ce45"
+          "2c15141a-8f6b-4575-8209-582f9730fe82"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "3AQJ-f0KUE_LQSuFO2iLjV1Wx3sXwlOOMgvUUM8JX5ol-J0LaN3KETOkyKsyz9ojpgVJ2Lg2AItT39pkIOBF4KtGkNwB2kkZR1cmxVKX63dul4QEvp7rQSEWw9BhGxk6b-sAVR2KgRuLQYznoklvWt7_eibmYJjoI5ICpFJjfZpRhUQVCmC1NV8n1h4YqPlqukOn9fA5HQlqSb_24ECr4w.MWfparLcWtqTeW1GcQMmazABCXfkMsXnYjAubSyW6nI"
+          "3VawMBE34HSaTOqsUorzoXjSM2juXuF8-VffhQsqfRtmrM2L5B2nhuDeaFcGTpTOgGkOZGmg48gZM3F65sd0q2dxW9L2IlpWGITC2jlWUaT6iDxx-NvaFLX0fbht6QaF.8JBMKtIFKtBVpuZ8op8RwN-8-Z8ZoGL7P9p53u3PFBQ"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1795,108 +1957,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "553559"
+          "1558923"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b/keyCredentials?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmIva2V5Q3JlZGVudGlhbHM/YXBpLXZlcnNpb249MS42",
-      "RequestMethod": "PATCH",
-      "RequestBody": "{\r\n  \"value\": [\r\n    {\r\n      \"customKeyIdentifier\": \"c3BjZXJ0\",\r\n      \"startDate\": \"2018-01-10T12:14:37.6976959Z\",\r\n      \"endDate\": \"2018-01-11T12:14:37.6976959Z\",\r\n      \"value\": \"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tDQpNSUlDd1RDQ0FhbWdBd0lCQWdJRUprNTJ1REFOQmdrcWhraUc5dzBCQVFzRkFEQVJNUTh3RFFZRFZRUURFd1p0DQplVlJsYzNRd0hoY05NVFl4TVRFeU1ERXhNekkyV2hjTk1qWXhNVEV3TURFeE16STJXakFSTVE4d0RRWURWUVFEDQpFd1p0ZVZSbGMzUXdnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDYm56SkYzYysvDQpzY2JnUnluc2l4eG1XbDNHZFppUUh2b0FjVWJXZUdkbDF1bzBSVDZYeThCQ0tkWENCUW9ZbXhuZzNYYnZTS2RiDQp2UGUyYmtHVDlBMDhxVTh5VXFUMGJFSXFXNUZCZ3g1ZEVzdzRUeCtuOXA3UWhKTWF3Nlg1NFZ1SlVieVVwNERaDQp2VGxlOTluMDBqR0hwdDZUQndqb0VJNnNET1M3WG5lblk5WVIxR1hEY00zcVdidklXVHJ6SmFxeXMxUmdTYnhnDQpjUklMbjg4NVZaWkx1dXlqVTZXaEpRRmZ4L2kzR1hLVDNaUDhyVTNlNmQ3cTBQalZBS3lGd2FNTlZlVTRWbURpDQo3a25HaHlDODRJWW8xT0ZLc0FjU1ZDYXhkU1FiT0dhZXh2RmFqMmpqb0tmdlkzZG40aW9vM3lJelNNSmdsZk1BDQpISFgveHpUa3gyN2xBZ01CQUFHaklUQWZNQjBHQTFVZERnUVdCQlNDUXVicXhkSVBVdS9QRVdxUmxTWHBLTEZ1DQpxVEFOQmdrcWhraUc5dzBCQVFzRkFBT0NBUUVBQ3A2WUNLdDhGamtQdW5sQ0lKUFZZeFJZUTNzdDdHL0pGMnk5DQowRWlQWlc4THNCOFFTL0dQcmNoQmFaZE9pMVNNTGtEdlMyQnozN3VuSks3WUY2WC9JWG1nYWNDSkpjTnlXci8wDQpJdURUNGYwaHUzVCtYeWZlMFRVeFZJQzRDYjhpY3c1SXBGMkVhZ1ZhY0VSVFpHQi91MzhZNzdGYTNKUlN4NHdaDQpuc0hUbVA0SlNLdU94UlprbkR3NS9nSEdIZkhyKzlueWNOSjdJSHJZS0tDRUVna2hEVXZVYXgzZk4zVFd5WmFwDQpSOThTK1JRYUozckxhTmlOcVZqdUdyYkhqUmVRaWtUdFp3Q3RscE04Vkhvdml5eVRVRTd4a2VrTTJwNFloRHBEDQpaRE4raTJPZ1VLc1NLbUR3clpUQzczMkQwRzdyODBmbDk2ZXpOTTlPN3FoNDU3aWhWQT09DQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tDQo=\",\r\n      \"usage\": \"Verify\",\r\n      \"type\": \"AsymmetricX509Cert\"\r\n    }\r\n  ]\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Content-Length": [
-          "1643"
-        ],
-        "x-ms-client-request-id": [
-          "96679405-6d06-41cb-af66-e9fb997dd1c0"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
-        ]
-      },
-      "ResponseBody": "",
-      "ResponseHeaders": {
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 10 Jan 2018 12:14:38 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "ocp-aad-diagnostics-server-name": [
-          "EmAW/3cq3T9S4P42xbgMBExuBExGKCe4J4aWuRotPBI="
-        ],
-        "request-id": [
-          "c5076c32-7c1c-4d98-aed7-fce6832f3da6"
-        ],
-        "client-request-id": [
-          "d0939cd9-6292-4dda-8733-e820bd1b99d2"
-        ],
-        "x-ms-dirapi-data-contract-version": [
-          "1.6"
-        ],
-        "ocp-aad-session-key": [
-          "eoyGX9dupw8MKKsHQ4GmI9sw8v_g0zC_R1O2HNReL9j92-vuPxxa0a7rbAbIT_pr7OVdMsV4Ya-6YFTKAeUpx4bWV1h_gB6PFvCYijIodasT9zuSWzlKAFS6JnJhhR8Ba7cO_UixIeBJUBBHo8ApFrlSU4HE8CJ8ev3D4fRe5Xf1JTledwIh2fd2TtI7_IR8ungLRTwGK--TIAbQsXJOPg.VrJQIN3kWNljpv5GUhwu1iFearCCI_v6ZoTCvFZ8qxI"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "DataServiceVersion": [
-          "1.0;"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ],
-        "Access-Control-Allow-Origin": [
-          "*"
-        ],
-        "X-AspNet-Version": [
-          "4.0.30319"
-        ],
-        "X-Powered-By": [
-          "ASP.NET",
-          "ASP.NET"
-        ],
-        "Duration": [
-          "3252455"
-        ]
-      },
-      "StatusCode": 204
-    },
-    {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/b0c31ede-cb7a-4ca7-b7de-d065e66a342b?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy9iMGMzMWVkZS1jYjdhLTRjYTctYjdkZS1kMDY1ZTY2YTM0MmI/YXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/servicePrincipals/9385acae-5eb2-4ea4-9d0d-ff88cd259d48?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9zZXJ2aWNlUHJpbmNpcGFscy85Mzg1YWNhZS01ZWIyLTRlYTQtOWQwZC1mZjg4Y2QyNTlkNDg/YXBpLXZlcnNpb249MS42",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "c3bb5fd7-b474-4978-8e45-ebeaef77167f"
+          "e44cfd38-83d8-41e2-a14c-ac1d371f6e88"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "",
@@ -1908,28 +1989,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:39 GMT"
+          "Wed, 27 Jun 2018 18:01:46 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "7YA/3TfBqGAsS+NzplT7OSD5qgbTFG5C07o9g15WtTM="
+          "n89Keg3phw3NGk9ObUqYNFrQ8gN7RlXt/txUE8fYons="
         ],
         "request-id": [
-          "c78b04da-3bb0-4b0d-864b-ee69a51d7b1d"
+          "53593626-d7dc-43a2-b3da-2d7d0bfb7812"
         ],
         "client-request-id": [
-          "c4a20199-8d90-49d5-9675-afe07a128adc"
+          "e2a4a882-cab9-4639-a20f-7044443b670a"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "TMxzkdYgfZQm4HOHJpibehpYS6Vqi_o7rnRcnNR5fjScc6vlEqOI90aFykuLs6Osgqy1blCgZ1ej4DTmbxfNpAUT0v5m-aCdFEpIbhKVDpOiDWM8twf6r-Qp1frzEpKHKO7-0RztwWb4OPhof4TOYYaPVH3UUSGofoxZY3rY0biLg5mAdoXfofJfrJFfnL0n5Suz3jYK_m9qg1TwvEPlmw.tpC5d0sruRV_0Rl3wFbUm56_56Sg5Dp1jVZGeZ56rXE"
+          "mhQiyC_h8zV9cPUDKa6_d0dIq8NyScqvgTOH5K8DxfPs43Go_C-zeQU35dZvu6AQdAXSYD1SXbrlcjQgWyMOkgRR13kX65W-tV4dkTki6-qSxg5CiejfOSlQLnH5-UFEtgB0znoUksSXIdUY223MPQ.iqLzz48o1mhUyb9lTopn4PgEtagZ4AjcfAOS9Rl04AA"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1951,27 +2032,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "2931631"
+          "1304836"
         ]
       },
       "StatusCode": 204
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications?$filter=displayName%20eq%20'ec8b883e-e279-4b37-a29a-8df0f56ac37e'&api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnM/JGZpbHRlcj1kaXNwbGF5TmFtZSUyMGVxJTIwJ2VjOGI4ODNlLWUyNzktNGIzNy1hMjlhLThkZjBmNTZhYzM3ZScmYXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications?$filter=displayName%20eq%20'f6b5daaa-69aa-4ad0-8c31-0c59b6586f39'&api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnM/JGZpbHRlcj1kaXNwbGF5TmFtZSUyMGVxJTIwJ2Y2YjVkYWFhLTY5YWEtNGFkMC04YzMxLTBjNTliNjU4NmYzOScmYXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "0199ea57-0357-4c16-8cfd-078db36f851c"
+          "5bbccc93-a19d-4adc-9c30-dd2ec559160f"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.Application\",\r\n  \"value\": []\r\n}",
@@ -1989,28 +2070,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:39 GMT"
+          "Wed, 27 Jun 2018 18:01:46 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "X7JJrDJZ6J5u3UjAG6S964BeoRqIrZ+Y1/baVMmjI9U="
+          "Fo1QicrIhHj2KR1ZzWvNa2KLRHgOjpt7/hmcNDActAs="
         ],
         "request-id": [
-          "d7216b3f-80c2-4238-971e-4f11d1450b27"
+          "cb9c5175-0118-4f09-b916-d63518d23305"
         ],
         "client-request-id": [
-          "9a5d75b3-a5de-4534-9db4-1d6848adb181"
+          "9bb41e2e-2f3d-49ae-90f8-ad443f24c33a"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "tC76pbxtJX51xjlCh3XLdbba4uvit5_BZ6ndIb7owcbc6PSBwJ_kKZPlLnM_YhRpEWIQ_vlPNs38zE3MhyuREdgAuoosAKSeDe2Q80ZFxJvDl4FG9dVYxRFFSPqa-J49ncBOIevzUAlCMRsM0d6UdfBLktcxurvTuH0HjgJrHhZSpYu7thTDpfneIyUMG32j5WqnR03pMTBBm13v43cAdA.APbszwoCzW7sJu9ebzytXbBWTcaXfFRaJiqpY8mTJyE"
+          "GyiCelSqjJ16GRIxCxrOfz7GO8WCjGjnow0um285TLIAMbPb2M5nzu1hn3A1zJyuD5E0Yy3wXBb9aI2zDibgc_AGzhxA-PFWEX58MxeQ05E7wY7Ls0M3VP1UGdkzOcC2g28UPew1-__bTuvrbzN_4A.x6rd1YQ9YC7hE9gJHB3gHGCYXkDZMDMYXoBjs3DQYQY"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -2032,33 +2113,33 @@
           "ASP.NET"
         ],
         "Duration": [
-          "581859"
+          "363469"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications?$filter=appId%20eq%20'ec8b883e-e279-4b37-a29a-8df0f56ac37e'&api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnM/JGZpbHRlcj1hcHBJZCUyMGVxJTIwJ2VjOGI4ODNlLWUyNzktNGIzNy1hMjlhLThkZjBmNTZhYzM3ZScmYXBpLXZlcnNpb249MS42",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications?$filter=appId%20eq%20'f6b5daaa-69aa-4ad0-8c31-0c59b6586f39'&api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnM/JGZpbHRlcj1hcHBJZCUyMGVxJTIwJ2Y2YjVkYWFhLTY5YWEtNGFkMC04YzMxLTBjNTliNjU4NmYzOScmYXBpLXZlcnNpb249MS42",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "3e48bc86-9c17-43d6-b846-9c0931a007b4"
+          "0031416a-b609-4595-8951-05294324aac0"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
-      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.Application\",\r\n  \"value\": [\r\n    {\r\n      \"odata.type\": \"Microsoft.DirectoryServices.Application\",\r\n      \"objectType\": \"Application\",\r\n      \"objectId\": \"1ee386e0-09f1-4fa9-a9e8-3d737ed1b219\",\r\n      \"deletionTimestamp\": null,\r\n      \"acceptMappedClaims\": null,\r\n      \"addIns\": [],\r\n      \"appId\": \"ec8b883e-e279-4b37-a29a-8df0f56ac37e\",\r\n      \"appRoles\": [],\r\n      \"availableToOtherTenants\": false,\r\n      \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"errorUrl\": null,\r\n      \"groupMembershipClaims\": null,\r\n      \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n      \"identifierUris\": [\r\n        \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\"\r\n      ],\r\n      \"informationalUrls\": {\r\n        \"termsOfService\": null,\r\n        \"support\": null,\r\n        \"privacy\": null,\r\n        \"marketing\": null\r\n      },\r\n      \"keyCredentials\": [],\r\n      \"knownClientApplications\": [],\r\n      \"logoutUrl\": null,\r\n      \"oauth2AllowImplicitFlow\": false,\r\n      \"oauth2AllowUrlPathMatching\": false,\r\n      \"oauth2Permissions\": [\r\n        {\r\n          \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on behalf of the signed-in user.\",\r\n          \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n          \"id\": \"8073ece8-3069-46c6-9146-322519e2fbb0\",\r\n          \"isEnabled\": true,\r\n          \"type\": \"User\",\r\n          \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp2a6567724 on your behalf.\",\r\n          \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp2a6567724\",\r\n          \"value\": \"user_impersonation\"\r\n        }\r\n      ],\r\n      \"oauth2RequirePostResponse\": false,\r\n      \"optionalClaims\": null,\r\n      \"passwordCredentials\": [],\r\n      \"publicClient\": null,\r\n      \"recordConsentConditions\": null,\r\n      \"replyUrls\": [\r\n        \"http://easycreate.azure.com/anotherapp/javasdksp2a6567724\"\r\n      ],\r\n      \"requiredResourceAccess\": [],\r\n      \"samlMetadataUrl\": null,\r\n      \"tokenEncryptionKeyId\": null,\r\n      \"isDeviceOnlyAuthSupported\": null\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"odata.metadata\": \"https://graph.windows.net/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/$metadata#directoryObjects/Microsoft.DirectoryServices.Application\",\r\n  \"value\": [\r\n    {\r\n      \"odata.type\": \"Microsoft.DirectoryServices.Application\",\r\n      \"objectType\": \"Application\",\r\n      \"objectId\": \"bc666b96-bd29-4675-813e-bf4b1e3b13d3\",\r\n      \"deletionTimestamp\": null,\r\n      \"acceptMappedClaims\": null,\r\n      \"addIns\": [],\r\n      \"appId\": \"f6b5daaa-69aa-4ad0-8c31-0c59b6586f39\",\r\n      \"appRoles\": [],\r\n      \"availableToOtherTenants\": false,\r\n      \"displayName\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"errorUrl\": null,\r\n      \"groupMembershipClaims\": null,\r\n      \"homepage\": \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n      \"identifierUris\": [\r\n        \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\"\r\n      ],\r\n      \"informationalUrls\": {\r\n        \"termsOfService\": null,\r\n        \"support\": null,\r\n        \"privacy\": null,\r\n        \"marketing\": null\r\n      },\r\n      \"isDeviceOnlyAuthSupported\": null,\r\n      \"keyCredentials\": [],\r\n      \"knownClientApplications\": [],\r\n      \"logoutUrl\": null,\r\n      \"logoUrl\": null,\r\n      \"oauth2AllowIdTokenImplicitFlow\": true,\r\n      \"oauth2AllowImplicitFlow\": false,\r\n      \"oauth2AllowUrlPathMatching\": false,\r\n      \"oauth2Permissions\": [\r\n        {\r\n          \"adminConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on behalf of the signed-in user.\",\r\n          \"adminConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n          \"id\": \"9494d843-fb44-4816-a4c8-87c32cfba7b9\",\r\n          \"isEnabled\": true,\r\n          \"type\": \"User\",\r\n          \"userConsentDescription\": \"Allow the application to access http://easycreate.azure.com/anotherapp/javasdksp7eb259463 on your behalf.\",\r\n          \"userConsentDisplayName\": \"Access http://easycreate.azure.com/anotherapp/javasdksp7eb259463\",\r\n          \"value\": \"user_impersonation\"\r\n        }\r\n      ],\r\n      \"oauth2RequirePostResponse\": false,\r\n      \"optionalClaims\": null,\r\n      \"orgRestrictions\": [],\r\n      \"parentalControlSettings\": {\r\n        \"countriesBlockedForMinors\": [],\r\n        \"legalAgeGroupRule\": \"Allow\"\r\n      },\r\n      \"passwordCredentials\": [],\r\n      \"publicClient\": null,\r\n      \"publisherDomain\": null,\r\n      \"recordConsentConditions\": null,\r\n      \"replyUrls\": [\r\n        \"http://easycreate.azure.com/anotherapp/javasdksp7eb259463\"\r\n      ],\r\n      \"requiredResourceAccess\": [],\r\n      \"samlMetadataUrl\": null,\r\n      \"signInAudience\": \"AzureADMyOrg\",\r\n      \"tokenEncryptionKeyId\": null\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "1858"
+          "2074"
         ],
         "Content-Type": [
           "application/json; odata=minimalmetadata; streaming=true; charset=utf-8"
@@ -2070,28 +2151,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:39 GMT"
+          "Wed, 27 Jun 2018 18:01:46 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "gzTHd9xPT6UpzqL1VdRsA3bqkd3Ju1OXrLwpKneHrpg="
+          "n89Keg3phw3NGk9ObUqYNFrQ8gN7RlXt/txUE8fYons="
         ],
         "request-id": [
-          "b9ce184b-5d98-492d-8cc4-27ab2b715c1d"
+          "a67ddc83-c682-4ad2-b845-598b871960f6"
         ],
         "client-request-id": [
-          "1eac32ca-ba68-4c18-9d4d-a06eb923c0a5"
+          "ee5e5252-42d7-41fb-9544-4ae18d72bd27"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "J101GO1rbX_C-iw85K_yvzCpVvn-hCmguYAhdfMmw-8HBQg_SQpKpnsiURh35fWkAUJC107ey2z9Ar6hL5oBGHcNMJDZVsCPt35KOvohzu7jT6mk3vZhLQyI4j3I3FoIe8Yum54cf8W1gb7sEheGcCeNnwI1CIgDUJddlQ9MMbaY-pJPeySNse_hfEOwpo5kkafWN3mTe4jm4Y9Gn0Wmyg.Sa_reHU-RCIzqm7zsAuN5TZlp8oBtIJ4_DMPR5w2XP4"
+          "9aWUkFeER0jlypRQvEDWL4JvhnHeJ0xdslPOjwDIpFZflPeRUqe1molVBJrO_B6vHRy2OIQC16kjgz4hPtDB4eVQp16d9F0uq-7TZQ-DIyfG4Jv5HcpayKMiZlzua3DC4wwHvT-GYVWAM-DdEJLI3g.SNfAEMU2Im3VR9aAgjqk6kzsYpF4_DTGowg34lvzCek"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -2113,27 +2194,27 @@
           "ASP.NET"
         ],
         "Duration": [
-          "561019"
+          "1824088"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/1ee386e0-09f1-4fa9-a9e8-3d737ed1b219?api-version=1.6",
-      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvMWVlMzg2ZTAtMDlmMS00ZmE5LWE5ZTgtM2Q3MzdlZDFiMjE5P2FwaS12ZXJzaW9uPTEuNg==",
+      "RequestUri": "/54826b22-38d6-4fb2-bad9-b7b93a3e9c5a/applications/bc666b96-bd29-4675-813e-bf4b1e3b13d3?api-version=1.6",
+      "EncodedRequestUri": "LzU0ODI2YjIyLTM4ZDYtNGZiMi1iYWQ5LWI3YjkzYTNlOWM1YS9hcHBsaWNhdGlvbnMvYmM2NjZiOTYtYmQyOS00Njc1LTgxM2UtYmY0YjFlM2IxM2QzP2FwaS12ZXJzaW9uPTEuNg==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "7080f567-9e63-4145-bf91-0b0d452e005c"
+          "798fcf3b-d2eb-4524-8282-6e025931d2f0"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.4.1.0",
-          "MacAddressHash/8aacf6245de346f347b0601b2da7a93ac9072c00fb7b723a469bc615c87f34d2"
+          "Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManagementClient/1.11.1.0",
+          "MacAddressHash/cc0dc995bd7689190d87305dca6418746f27065181fa649f43731fb8fc5f1b10"
         ]
       },
       "ResponseBody": "",
@@ -2145,28 +2226,28 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 10 Jan 2018 12:14:40 GMT"
+          "Wed, 27 Jun 2018 18:01:46 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Server": [
-          "Microsoft-IIS/8.5"
+          "Microsoft-IIS/10.0"
         ],
         "ocp-aad-diagnostics-server-name": [
-          "K7+AvfaamY7DwcxlbHLJ+P0optdxEzfgDUCXy1QyENk="
+          "WBvu8jP7GvGe2O2F+aZuMDfZG7V2TvhyRVdWPfSUkTU="
         ],
         "request-id": [
-          "c0e8ab2c-567a-4ad5-9850-5631bcbbe55a"
+          "a52de819-3597-466e-8281-edb0c93e4ef7"
         ],
         "client-request-id": [
-          "680b2e2e-106a-4e72-bd59-5720bfaaf252"
+          "4c379a6a-0f4c-4c77-a0dd-9d1bb80dafd5"
         ],
         "x-ms-dirapi-data-contract-version": [
           "1.6"
         ],
         "ocp-aad-session-key": [
-          "g9_hJxPj8blz4uz7FGRhZnX0PDjk5D2D8k_-7eceXBZYhoNMeip8h5moJjjKpmJ8QWMABMvsnBOCTUzOO3rtHKKEbwAMbEz0846WyZVcsBXfN8ojoZ4S-MkyAFyr8uo89_ewmOFruJTAi16cCxNVQFiQ5pdNyGXuwRgEV7kLYkaxir8X2-41pJMh4uOhIXiX4D2FpS_a9nbmE2YJoZpBHQ.MQPivPtpE4CjY9jJRMBwDkysZ997UGmV4PUoyt2Rt6E"
+          "3XgKj0Hnw_HDprWWnm1D8CFskSDmtM6RxFwwZmirlOFLTG_iwepT5HXYHV1gjQ_VFNmemsW5n6ti7KYIxXRmQrstO34d6nK2dEb_9dVkhY2RG_QIgB1qvsrjLtVEKBSbbNr-eNybspIFar0UVPZubA.iS_dK97RrQJtmiNmrVd1r1LqNZUcsq9E1fNXcC6geh4"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -2188,7 +2269,7 @@
           "ASP.NET"
         ],
         "Duration": [
-          "2486328"
+          "1094188"
         ]
       },
       "StatusCode": 204
@@ -2196,11 +2277,11 @@
   ],
   "Names": {
     "CanCRUDServicePrincipal": [
-      "javasdksp2a6567724"
+      "javasdksp7eb259463"
     ]
   },
   "Variables": {
-    "ServicePrincipal": "a971e5df-eeb7-4481-9bf7-e72e66a2ba12",
+    "ServicePrincipal": "39e3d217-cb72-4b90-8532-394a7e784d93",
     "AADTenant": "54826b22-38d6-4fb2-bad9-b7b93a3e9c5a",
     "SubscriptionId": "0b1f6471-1bf0-4dda-aec3-cb9272f09590"
   }

--- a/src/ResourceManagement/Graph.RBAC/ActiveDirectoryApplicationImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ActiveDirectoryApplicationImpl.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             foreach (var cred in keyCredentials)
             {
                 ICertificateCredential cert = new CertificateCredentialImpl<IActiveDirectoryApplication>(cred);
-                this.cachedCertificateCredentials.Add(cert.Name, cert);
+                this.cachedCertificateCredentials.Add(cert.Id, cert);
             }
 
             IEnumerable<Models.PasswordCredential> passwordCredentials = await manager.Inner.Applications.ListPasswordCredentialsAsync(Id(), cancellationToken);
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             foreach (var cred in passwordCredentials)
             {
                 IPasswordCredential cert = new PasswordCredentialImpl<IActiveDirectoryApplication>(cred);
-                this.cachedPasswordCredentials.Add(cert.Name, cert);
+                this.cachedPasswordCredentials.Add(cert.Id, cert);
             }
 
             return this;
@@ -290,15 +290,23 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         public ActiveDirectoryApplicationImpl WithoutCredential(string name)
         {
-            if (cachedPasswordCredentials.ContainsKey(name))
+            foreach (var credential in cachedPasswordCredentials)
             {
-                cachedPasswordCredentials.Remove(name);
-                updateParameters.PasswordCredentials = cachedPasswordCredentials.Values.Select(pc => pc.Inner).ToList();
+                if (name.Equals(credential.Value.Name))
+                {
+                    cachedPasswordCredentials.Remove(credential.Value.Id);
+                    updateParameters.PasswordCredentials = cachedPasswordCredentials.Values.Select(pc => pc.Inner).ToList();
+                    return this;
+                }
             }
-            else if (cachedCertificateCredentials.ContainsKey(name))
+            foreach (var credential in cachedCertificateCredentials)
             {
-                cachedCertificateCredentials.Remove(name);
-                updateParameters.KeyCredentials = cachedCertificateCredentials.Values.Select(pc => pc.Inner).ToList();
+                if (name.Equals(credential.Value.Name))
+                {
+                    cachedCertificateCredentials.Remove(credential.Value.Id);
+                    updateParameters.KeyCredentials = cachedCertificateCredentials.Values.Select(pc => pc.Inner).ToList();
+                    return this;
+                }
             }
             return this;
         }

--- a/src/ResourceManagement/Graph.RBAC/Domain/IActiveDirectoryApplication.cs
+++ b/src/ResourceManagement/Graph.RBAC/Domain/IActiveDirectoryApplication.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
         string ApplicationId { get; }
 
         /// <summary>
-        /// Gets the mapping of certificate credentials from their names.
+        /// Gets the mapping of certificate credentials from their ids.
         /// </summary>
         System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Azure.Management.Graph.RBAC.Fluent.ICertificateCredential> CertificateCredentials { get; }
 
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
         bool AvailableToOtherTenants { get; }
 
         /// <summary>
-        /// Gets the mapping of password credentials from their names.
+        /// Gets the mapping of password credentials from their ids.
         /// </summary>
         System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Azure.Management.Graph.RBAC.Fluent.IPasswordCredential> PasswordCredentials { get; }
 

--- a/src/ResourceManagement/Graph.RBAC/Domain/IServicePrincipal.cs
+++ b/src/ResourceManagement/Graph.RBAC/Domain/IServicePrincipal.cs
@@ -33,12 +33,12 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
         string ApplicationId { get; }
 
         /// <summary>
-        /// Gets the mapping of certificate credentials from their names.
+        /// Gets the mapping of certificate credentials from their ids.
         /// </summary>
         System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Azure.Management.Graph.RBAC.Fluent.ICertificateCredential> CertificateCredentials { get; }
 
         /// <summary>
-        /// Gets the mapping of password credentials from their names.
+        /// Gets the mapping of password credentials from their ids.
         /// </summary>
         System.Collections.Generic.IReadOnlyDictionary<string, Microsoft.Azure.Management.Graph.RBAC.Fluent.IPasswordCredential> PasswordCredentials { get; }
     }

--- a/src/ResourceManagement/Graph.RBAC/ServicePrincipalImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ServicePrincipalImpl.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
                 foreach (ICertificateCredential create in certificateCredentialsToCreate)
                 {
-                    newCerts.Add(create.Id, create);
+                    newCerts.Add(create.Name, create);
                 }
                 await Manager().Inner.ServicePrincipals.UpdateKeyCredentialsAsync(
                     sp.Id,
@@ -315,7 +315,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
                 foreach (IPasswordCredential create in passwordCredentialsToCreate)
                 {
-                    newPasses.Add(create.Id, create);
+                    newPasses.Add(create.Name, create);
                 }
                 await Manager().Inner.ServicePrincipals.UpdatePasswordCredentialsAsync(
                     sp.Id,

--- a/src/ResourceManagement/Graph.RBAC/ServicePrincipalImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ServicePrincipalImpl.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 foreach (var cred in keyCredentials)
                 {
                     ICertificateCredential cert = new CertificateCredentialImpl<IServicePrincipal>(cred);
-                    this.cachedCertificateCredentials.Add(cert.Name, cert);
+                    this.cachedCertificateCredentials.Add(cert.Id, cert);
                 }
             }
 
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 foreach (var cred in passwordCredentials)
                 {
                     IPasswordCredential cert = new PasswordCredentialImpl<IServicePrincipal>(cred);
-                    this.cachedPasswordCredentials.Add(cert.Name, cert);
+                    this.cachedPasswordCredentials.Add(cert.Id, cert);
                 }
             }
 
@@ -114,13 +114,21 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         public ServicePrincipalImpl WithoutCredential(string name)
         {
-            if (cachedPasswordCredentials.ContainsKey(name))
+            foreach (var credential in cachedPasswordCredentials.Values)
             {
-                passwordCredentialsToDelete.Add(name);
+                if (name.Equals(credential.Name))
+                {
+                    passwordCredentialsToDelete.Add(credential.Id);
+                    return this;
+                }
             }
-            else if (cachedCertificateCredentials.ContainsKey(name))
+            foreach (var credential in cachedCertificateCredentials.Values)
             {
-                certificateCredentialsToDelete.Add(name);
+                if (name.Equals(credential.Name))
+                {
+                    certificateCredentialsToDelete.Add(credential.Id);
+                    return this;
+                }
             }
             return this;
         }
@@ -291,7 +299,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
                 foreach (ICertificateCredential create in certificateCredentialsToCreate)
                 {
-                    newCerts.Add(create.Name, create);
+                    newCerts.Add(create.Id, create);
                 }
                 await Manager().Inner.ServicePrincipals.UpdateKeyCredentialsAsync(
                     sp.Id,
@@ -307,7 +315,7 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
                 }
                 foreach (IPasswordCredential create in passwordCredentialsToCreate)
                 {
-                    newPasses.Add(create.Name, create);
+                    newPasses.Add(create.Id, create);
                 }
                 await Manager().Inner.ServicePrincipals.UpdatePasswordCredentialsAsync(
                     sp.Id,


### PR DESCRIPTION
Fixing issue #356  Get service principal fails when service principal has multiple keys with the same name

Note: this is a breaking change as getters for credentials previously returned Dictionary indexed by name and now return Dictionary indexed by id.