### PR TITLE
Add IAuthenticated.WithDefaultSubscriptionAsync() method

### DIFF
--- a/src/ResourceManagement/Azure.Fluent/Azure.cs
+++ b/src/ResourceManagement/Azure.Fluent/Azure.cs
@@ -844,7 +844,7 @@ namespace Microsoft.Azure.Management.Fluent
                 else
                 {
                     var resourceManager = GetResourceManager();
-                    var subscriptions = await resourceManager.Subscriptions.ListAsync();
+                    var subscriptions = await resourceManager.Subscriptions.ListAsync().ConfigureAwait(false);
                     var subscription = GetDefaultSubscription(subscriptions);
 
                     return WithSubscription(subscription?.SubscriptionId);


### PR DESCRIPTION
Currently, using `IAuthenticated.WithDefaultSubscription()` makes a blocking API call.
This PR adds an asynchronous version of the method so that the consumer doesn't need to block their current thread.  

Sample usage:
```cs
AzureCredentials creds = new AzureCredentialsFactory().FromServicePrincipal(
	_azureConfig.ServicePrincipalUsername, _azureConfig.ServicePrincipalPassword, _azureConfig.Tenant,
	AzureEnvironment.AzureGlobalCloud);

IAzure azure = await Microsoft.Azure.Management.Fluent.Azure.Authenticate(creds)
    .WithDefaultSubscriptionAsync();
```