### PR TITLE
Add constructor taking tenant id as parameter for AzureCredentials constructor when using MSI

### DIFF
--- a/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
@@ -75,8 +75,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
             this.servicePrincipalLoginInformation = servicePrincipalLoginInformation;
         }
 
-        public AzureCredentials(MSILoginInformation msiLoginInformation, AzureEnvironment environment)
-            : this(tenantId: null, environment: environment)
+        public AzureCredentials(MSILoginInformation msiLoginInformation, AzureEnvironment environment, string tenantId = null)
+            : this(tenantId: tenantId, environment: environment)
         {
             this.msiTokenProviderFactory = new MSITokenProviderFactory(msiLoginInformation);
         }

--- a/src/ResourceManagement/ResourceManager/Authentication/AzureCredentialsFactory.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/AzureCredentialsFactory.cs
@@ -59,9 +59,9 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
         /// <param name="msiLoginInformation">the information needed for MSI authentication</param>
         /// <param name="environment">the environment to authenticate to</param>
         /// <returns>an authenticated credentials object</returns>
-        public AzureCredentials FromMSI(MSILoginInformation msiLoginInformation, AzureEnvironment environment)
+        public AzureCredentials FromMSI(MSILoginInformation msiLoginInformation, AzureEnvironment environment, string tenantId = null)
         {
-            return new AzureCredentials(msiLoginInformation, environment);
+            return new AzureCredentials(msiLoginInformation, environment, tenantId);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #661