### PR TITLE
Change tempDisk value on VirtualMachineScaleSetVM Reimage to null from false

### DIFF
--- a/src/ResourceManagement/Compute/VirtualMachineScaleSetVMImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineScaleSetVMImpl.cs
@@ -511,7 +511,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
                 Parent.ResourceGroupName,
                 Parent.Name,
                 InstanceId(),
-                false,
+                null,
                 null,
                 cancellationToken);
         }


### PR DESCRIPTION
False for this field throws exceptions, null was tested to work. This addresses [issue #663](https://github.com/Azure/azure-libraries-for-net/issues/663).