### PR TITLE
Add support for user-assigned MSIs from AppServices to MSITokenProvider

### DIFF
--- a/src/ResourceManagement/ResourceManager/Authentication/MSITokenProvider.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/MSITokenProvider.cs
@@ -79,7 +79,18 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
         {
             var endpoint = Environment.GetEnvironmentVariable("MSI_ENDPOINT") ?? throw new ArgumentNullException("MSI_ENDPOINT");
             var secret = Environment.GetEnvironmentVariable("MSI_SECRET") ?? throw new ArgumentNullException("MSI_SECRET");
-            HttpRequestMessage msiRequest = new HttpRequestMessage(HttpMethod.Get, $"{endpoint}?resource={resource}&api-version={MSITokenProvider.appServiceMsiApiVersion}");
+
+            string extraQueryArgs = string.Empty;
+            if (this.msiLoginInformation.UserAssignedIdentityClientId != null)
+            {
+                extraQueryArgs = $"{extraQueryArgs}&clientid={this.msiLoginInformation.UserAssignedIdentityClientId}";
+            }
+            else if (this.msiLoginInformation.UserAssignedIdentityObjectId != null || this.msiLoginInformation.UserAssignedIdentityResourceId != null)
+            {
+                throw new ArgumentException("UserAssignedIdentityObjectId/UserAssignedIdentityResourceId not supported in AppService environments");
+            }
+
+            HttpRequestMessage msiRequest = new HttpRequestMessage(HttpMethod.Get, $"{endpoint}?resource={resource}&api-version={MSITokenProvider.appServiceMsiApiVersion}{extraQueryArgs}");
             msiRequest.Headers.Add("Metadata", "true");
             msiRequest.Headers.Add("Secret", secret);
 


### PR DESCRIPTION
The `.AppService` codepaths in `MSITokenProvider` did not support user-assigned MSIs, only system-assigned MSIs (while the `.VirtualMachine` paths support both).  This change refactors `MSITokenProvider` slightly to leverage the logic the `.VirtualMachine` path is already using in the `.AppService` path as well.

Fixes #734