### PR TITLE
fix cosmosdb

### DIFF
--- a/Tests/Fluent.Tests/ManagementClientTest.cs
+++ b/Tests/Fluent.Tests/ManagementClientTest.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Xunit;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+using Microsoft.Azure.Management.ResourceManager.Fluent;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
+using Microsoft.Azure.Management.Fluent;
+using Microsoft.Rest.Azure;
+using System;
+
+namespace Fluent.Tests
+{
+    public class ManagementClientTest
+    {
+        [Fact]
+        public void ManagementClientBaseUri()
+        {
+            AzureEnvironment environment = AzureEnvironment.AzureUSGovernment;
+            AzureCredentials credentials = new AzureCredentialsFactory().FromServicePrincipal("mockId", "mockSecret", "mockTenant", environment);
+            IAzure azure = Microsoft.Azure.Management.Fluent.Azure.Authenticate(credentials).WithSubscription("mockSubscription");
+
+            // check that BaseUri in client is correctly set
+            foreach (IAzureClient client in azure.ManagementClients)
+            {
+                if (client is Microsoft.Azure.Management.CosmosDB.Fluent.CosmosDB)
+                {
+                    Assert.Equal(new Uri(environment.ResourceManagerEndpoint).Host, (client as Microsoft.Azure.Management.CosmosDB.Fluent.CosmosDB).BaseUri.Host);
+                }
+            }
+        }
+    }
+}

--- a/src/ResourceManagement/CosmosDB/Generated/CosmosDB.cs
+++ b/src/ResourceManagement/CosmosDB/Generated/CosmosDB.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Management.CosmosDB.Fluent
         /// <summary>
         /// The base URI of the service.
         /// </summary>
-        public System.Uri BaseUri { get; set; }
+        //public System.Uri BaseUri { get; set; }
 
         /// <summary>
         /// Gets or sets json serialization settings.


### PR DESCRIPTION
In short, the root cause is that manager.Inner.BaseUri = https://management.azure.com/ (which should not even be there) is hiding the real one (manager.Inner as FluentServiceClientBase<CosmosDB>).BaseUri = https://management.usgovcloudapi.net/