### PR TITLE
Use concurrent dictionary for accessing the credentials cache.

### DIFF
--- a/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
+++ b/src/ResourceManagement/ResourceManager/Authentication/AzureCredentials.cs
@@ -5,6 +5,7 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
 using Microsoft.Rest.Azure.Authentication;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -101,7 +102,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Authentication
         {
             TenantId = tenantId;
             Environment = environment;
-            credentialsCache = new Dictionary<Uri, ServiceClientCredentials>();
+            credentialsCache = new ConcurrentDictionary<Uri, ServiceClientCredentials>();
         }
 
         public AzureCredentials WithDefaultSubscription(string subscriptionId)


### PR DESCRIPTION
Since the AzureCredentials object may be accessed by different threads it must be a ConcurrentDictionary or be protected by synchronization primitives.