### PR TITLE
WithoutReplyUrl must add existing Reply URLs

### DIFF
--- a/src/ResourceManagement/Graph.RBAC/ActiveDirectoryApplicationImpl.cs
+++ b/src/ResourceManagement/Graph.RBAC/ActiveDirectoryApplicationImpl.cs
@@ -281,10 +281,11 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
 
         public ActiveDirectoryApplicationImpl WithoutReplyUrl(string replyUrl)
         {
-            if (updateParameters.ReplyUrls != null)
+            if (updateParameters.ReplyUrls == null)
             {
-                updateParameters.ReplyUrls.Remove(replyUrl);
+                updateParameters.ReplyUrls = new List<string>(this.Inner.ReplyUrls);
             }
+            updateParameters.ReplyUrls.Remove(replyUrl);
             return this;
         }
 


### PR DESCRIPTION
WithoutReplyUrl must add existing Reply URLs before attempting to remove one (see WithReplyUrl in update mode for similar logic).

If not added, the updateParameters.ReplyUrls will be null and nothing will happen.