### PR TITLE
fix: parentResourceId could not be null

### DIFF
--- a/Tests/Fluent.Tests/ResourceManager/GenericResourcesTests.cs
+++ b/Tests/Fluent.Tests/ResourceManager/GenericResourcesTests.cs
@@ -38,7 +38,6 @@ namespace Fluent.Tests.ResourceManager
                         .WithProviderNamespace("Microsoft.Web")
                         .WithoutPlan()
                         .WithApiVersion("2015-08-01")
-                        .WithParentResource("")
                         .WithProperties(JsonConvert.DeserializeObject("{\"SiteMode\":\"Limited\",\"ComputeMode\":\"Shared\"}"))
                         .Create();
 

--- a/src/ResourceManagement/ResourceManager/GenericResource/GenericResourceImpl.cs
+++ b/src/ResourceManagement/ResourceManager/GenericResource/GenericResourceImpl.cs
@@ -87,10 +87,16 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         {
         }
 
+        public void prepareDefaultValue()
+        {
+            this.parentResourceId = this.parentResourceId ?? "";
+        }
+
         #region Implementation of IResourceCreator interface
 
         public async override Task<IGenericResource> CreateResourceAsync(CancellationToken cancellationToken)
         {
+            prepareDefaultValue();
             GenericResourceInner inner = await Manager.Inner.Resources.CreateOrUpdateAsync(ResourceGroupName,
                 resourceProviderNamespace,
                 parentResourceId,


### PR DESCRIPTION
https://github.com/Azure/azure-libraries-for-net/issues/42