### PR TITLE
Add vault secret support for windows machines

### DIFF
--- a/src/ResourceManagement/Compute/Domain/InterfaceImpl/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/Domain/InterfaceImpl/VirtualMachineImpl.cs
@@ -2440,6 +2440,36 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         }
 
         /// <summary>
+        /// Specifies a vault secret to add to the vm.
+        /// Each call to this method adds to the list of vault secrets.
+        /// </summary>
+        /// <param name="vaultId">The vault id.</param>
+        /// <param name="certificateStore">The vm certificate store e.g. "My".</param>
+        /// <param name="certificateUrl">The vault certificate URL.</param>
+        /// <return>The stage representing creatable Windows VM definition.</return>
+        VirtualMachine.Definition.IWithWindowsCreateUnmanaged VirtualMachine.Definition.IWithWindowsCreateUnmanaged.WithVaultSecret(
+            string vaultId, string certificateUrl, string certificateStore)
+        {
+            return this.WithVaultSecret(vaultId, certificateUrl, certificateStore);
+        }
+
+        /// <summary>
+        /// Specifies a vault secret to add to the vm.
+        /// Each call to this method adds to the list of vault secrets.
+        /// </summary>
+        /// <param name="vaultId">The vault id.</param>
+        /// <param name="certificateStore">The vm certificate store e.g. "My".</param>
+        /// <param name="certificateUrl">The vault certificate URL.</param>
+        /// <return>The stage representing creatable Windows VM definition.</return>
+        VirtualMachine.Definition.IWithWindowsCreateManaged VirtualMachine.Definition.IWithWindowsCreateManaged.WithVaultSecret(
+            string vaultId, string certificateUrl, string certificateStore)
+        {
+            return this.WithVaultSecret(vaultId, certificateUrl, certificateStore );
+        }
+
+
+
+        /// <summary>
         /// Specifies a new priority for the virtual machine.
         /// </summary>
         /// <param name="priority">a priority from the list of available priority types.</param>

--- a/src/ResourceManagement/Compute/Domain/VirtualMachine/Definition/IDefinition.cs
+++ b/src/ResourceManagement/Compute/Domain/VirtualMachine/Definition/IDefinition.cs
@@ -364,6 +364,17 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         /// <param name="listener">A WinRM listener.</param>
         /// <return>The next stage of the definition.</return>
         Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateManaged WithWinRM(WinRMListener listener);
+
+        /// <summary>
+        /// Specifies a vault secret to add to the vm.
+        /// Each call to this method adds to the list of vault secrets.
+        /// </summary>
+        /// <param name="vaultId">The vault id.</param>
+        /// <param name="certificateStore">The vm certificate store e.g. "My".</param>
+        /// <param name="certificateUrl">The vault certificate URL.</param>
+        /// <return>The stage representing creatable Windows VM definition.</return>
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateManaged WithVaultSecret(string vaultId, string certificateUrl, string certificateStore);
+
     }
 
     /// <summary>
@@ -453,6 +464,16 @@ namespace Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition
         /// <param name="listener">The WinRMListener.</param>
         /// <return>The stage representing creatable Windows VM definition.</return>
         Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateUnmanaged WithWinRM(WinRMListener listener);
+
+        /// <summary>
+        /// Specifies a vault secret to add to the vm.
+        /// Each call to this method adds to the list of vault secrets.
+        /// </summary>
+        /// <param name="vaultId">The vault id.</param>
+        /// <param name="certificateStore">The vm certificate store e.g. "My".</param>
+        /// <param name="certificateUrl">The vault certificate URL.</param>
+        /// <return>The stage representing creatable Windows VM definition.</return>
+        Microsoft.Azure.Management.Compute.Fluent.VirtualMachine.Definition.IWithWindowsCreateUnmanaged WithVaultSecret(string vaultId, string certificateUrl, string certificateStore);
     }
 
     /// <summary>

--- a/src/ResourceManagement/Compute/VirtualMachineImpl.cs
+++ b/src/ResourceManagement/Compute/VirtualMachineImpl.cs
@@ -690,6 +690,32 @@ namespace Microsoft.Azure.Management.Compute.Fluent
             return this;
         }
 
+        public VirtualMachineImpl WithVaultSecret(string vaultId, string certificateUrl, string certificateStore)
+        {
+
+            if (Inner.OsProfile.Secrets == null)
+            {
+                Inner.OsProfile.Secrets = new List<VaultSecretGroup>();
+            }
+
+            var secretGroup = Inner.OsProfile.Secrets.FirstOrDefault(secret =>
+                secret.SourceVault.Id.Equals(vaultId, StringComparison.OrdinalIgnoreCase));
+
+            if (secretGroup == null)
+            {
+                secretGroup = new VaultSecretGroup(new SubResource(vaultId));
+                Inner.OsProfile.Secrets.Add(secretGroup);
+            }
+
+            if(secretGroup.VaultCertificates == null)
+            {
+                secretGroup.VaultCertificates = new List<VaultCertificate>();
+            }
+            secretGroup.VaultCertificates.Add(new VaultCertificate(certificateUrl,certificateStore));
+
+            return this;
+        }
+
         ///GENMHASH:F2FFAF5448D7DFAFBE00130C62E87053:31B639B9D779BF92E26C4DAAF832C9E7
         public VirtualMachineImpl WithRootPassword(string password)
         {


### PR DESCRIPTION
add WithVaultSecret to windows managed and unmanaged definitions. This is needed in order to use WithWinRM.

Fixes #660 