### PR TITLE
Resources: support TaskCanceledException handling for different .NET environment

### DIFF
--- a/src/ResourceManagement/ResourceManager/Core/ExternalChildResourceCollection.cs
+++ b/src/ResourceManagement/ResourceManager/Core/ExternalChildResourceCollection.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                                 exceptions.Add(deleteTask.Exception);
                             }
                         }
-                        if (deleteTask.IsCanceled)
+                        else if (deleteTask.IsCanceled)
                         {
                             exceptions.Add(new TaskCanceledException());
                         }

--- a/src/ResourceManagement/ResourceManager/Core/ExternalChildResourceCollection.cs
+++ b/src/ResourceManagement/ResourceManager/Core/ExternalChildResourceCollection.cs
@@ -69,12 +69,15 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                                 exceptions.Add(deleteTask.Exception);
                             }
                         }
+                        if (deleteTask.IsCanceled)
+                        {
+                            exceptions.Add(new TaskCanceledException());
+                        }
                         else
                         {
                             comitted.Add(res);
                             res.PendingOperation = PendingOperation.None;
-                            FluentModelTImpl val;
-                            this.collection.TryRemove(res.Name(), out val);
+                            this.collection.TryRemove(res.Name(), out FluentModelTImpl val);
                         }
                     },
                     cancellationToken,
@@ -91,8 +94,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                     {
                         if (createTask.IsFaulted)
                         {
-                            FluentModelTImpl val;
-                            this.collection.TryRemove(res.Name(), out val);
+                            this.collection.TryRemove(res.Name(), out FluentModelTImpl val);
                             if (createTask.Exception.InnerException != null)
                             {
                                 exceptions.Add(createTask.Exception.InnerException);
@@ -101,6 +103,11 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                             {
                                 exceptions.Add(createTask.Exception);
                             }
+                        }
+                        else if (createTask.IsCanceled)
+                        {
+                            this.collection.TryRemove(res.Name(), out FluentModelTImpl val);
+                            exceptions.Add(new TaskCanceledException());
                         }
                         else
                         {
@@ -130,6 +137,10 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                             {
                                 exceptions.Add(updateTask.Exception);
                             }
+                        }
+                        else if (updateTask.IsCanceled)
+                        {
+                            exceptions.Add(new TaskCanceledException());
                         }
                         else
                         {

--- a/src/ResourceManagement/ResourceManager/Core/ExternalChildResourceCollection.cs
+++ b/src/ResourceManagement/ResourceManager/Core/ExternalChildResourceCollection.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                         }
                         else if (deleteTask.IsCanceled)
                         {
+                            cancellationToken.ThrowIfCancellationRequested();
                             exceptions.Add(new TaskCanceledException());
                         }
                         else
@@ -107,6 +108,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                         else if (createTask.IsCanceled)
                         {
                             this.collection.TryRemove(res.Name(), out FluentModelTImpl val);
+                            cancellationToken.ThrowIfCancellationRequested();
                             exceptions.Add(new TaskCanceledException());
                         }
                         else
@@ -140,6 +142,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                         }
                         else if (updateTask.IsCanceled)
                         {
+                            cancellationToken.ThrowIfCancellationRequested();
                             exceptions.Add(new TaskCanceledException());
                         }
                         else


### PR DESCRIPTION
Fix #1002 
This was caused by the difference from dotnet frameworks when getting TaskCanceledException. For example, `netcoreapp2.0` will set task as `Faulted` while `net461` will set as `Canceled`.