### PR TITLE
Define a container instance with both an empty directory defined and an existing volume 

### DIFF
--- a/src/ResourceManagement/ContainerInstance/Domain/ContainerGroup/Definition/IDefinition.cs
+++ b/src/ResourceManagement/ContainerInstance/Domain/ContainerGroup/Definition/IDefinition.cs
@@ -353,7 +353,9 @@ namespace Microsoft.Azure.Management.ContainerInstance.Fluent.ContainerGroup.Def
     /// The stage of the container group definition allowing to specify a volume that can be mounted by a container instance.
     /// </summary>
     public interface IWithVolume :
-        Microsoft.Azure.Management.ContainerInstance.Fluent.ContainerGroup.Definition.IWithFirstContainerInstance
+        Microsoft.Azure.Management.ContainerInstance.Fluent.ContainerGroup.Definition.IWithFirstContainerInstance,
+        Microsoft.Azure.Management.ContainerInstance.Fluent.ContainerGroup.Definition.IWithPrivateImageRegistryOrVolumeBeta
+
     {
 
         /// <summary>


### PR DESCRIPTION
Addresses feature request #1068 

Currently you cannot define a container instance via the .NET SDK that has both an empty directory defined and a volume mapping to Azure Files.

The issue is that as with the fluent API soon as I use WithEmptyDirectoryVolume , you cannot then use DefineVolume and visa versa.

This PR means that you can now do this

```
            var containerGroup = azure.ContainerGroups.Define(cgName)
...
                .WithPrivateImageRegistry(imageServer, imageUser, imagePassword)
                .DefineVolume("existingvolume")
...
                .Attach()
                .WithEmptyDirectoryVolume("emptyvolume")
                .DefineContainerInstance(cgName + "-1")
...

```