### PR TITLE
Fixed the get method of Rules in AzureFirewallNatRuleCollectionImpl

### DIFF
--- a/src/ResourceManagement/Network/AzureFirewallNatRuleCollectionImpl.cs
+++ b/src/ResourceManagement/Network/AzureFirewallNatRuleCollectionImpl.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Management.Network.Fluent
                 List<AzureFirewallNatRule> rules = new List<AzureFirewallNatRule>();
                 if (Inner.Rules != null)
                 {
-                    rules = new List<AzureFirewallNatRule>();
+                    rules.AddRange(Inner.Rules);
                 }
                 return rules.AsReadOnly();
             }


### PR DESCRIPTION
Fixed the get method to return the existing rules instead of an empty list