### PR TITLE
Fix regex to allow wildcard subdomain

### DIFF
--- a/src/ResourceManagement/AppService/HostNameBindingImpl.cs
+++ b/src/ResourceManagement/AppService/HostNameBindingImpl.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         ///GENMHASH:027705B70337BE533ED77421800E496A:3479885A232C974264B5B36BDBB0BC94
         public HostNameBindingImpl<FluentT, FluentImplT, DefAfterRegionT, DefAfterGroupT, UpdateT> WithDnsRecordType(CustomHostNameDnsRecordType hostNameDnsRecordType)
         {
-            var regex = new Regex("([.\\w-]+)\\.([\\w-]+\\.\\w+)");
+            var regex = new Regex("([.\\w-]+|[*])\\.([\\w-]+\\.\\w+)");
             var matcher = regex.Match(name);
             if (hostNameDnsRecordType == CustomHostNameDnsRecordType.CName && !matcher.Success)
             {


### PR DESCRIPTION
I couldn't add hostname binding with wildcard subdomain though it can be done via azure portal. Tweaked regex expression a bit, so it could match wildcard