### PR TITLE
Release 1.36.1 due to assemblyFileVersion need update

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,11 +27,11 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <FluentVersion>1.36.0</FluentVersion>
+    <FluentVersion>1.36.1</FluentVersion>
     <VersionPrefix>$(FluentVersion)</VersionPrefix>
 
-    <!-- Keep the assembly version pinned unless a breaking change is made -->
-    <AssemblyVersion>1.0.0.66</AssemblyVersion>
+    <!-- Always update AssemblyVersion for new release -->
+    <AssemblyVersion>1.0.0.67</AssemblyVersion>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
@weidongxu-microsoft @xccc-msft @yungezz It seems the AssemblyVersion will affect the DLL version, which causes that customer cannot auto-update their DLL. I'm not sure the problem details due to we do not use AssemblyFileVersion in the project. So I think the most convenient way is update it every time we release.