### PR TITLE
Adjusted helper methods to the new Premium tier service app plans

### DIFF
--- a/src/ResourceManagement/AppService/FunctionAppImpl.cs
+++ b/src/ResourceManagement/AppService/FunctionAppImpl.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             SkuDescription description = pricingTier.SkuDescription;
             if (description.Tier.Equals("Basic", StringComparison.OrdinalIgnoreCase)
                 || description.Tier.Equals("Standard", StringComparison.OrdinalIgnoreCase)
-                || description.Tier.Equals("Premium", StringComparison.OrdinalIgnoreCase))
+                || description.Tier.StartsWith("Premium", StringComparison.OrdinalIgnoreCase))
             {
                 return WithWebAppAlwaysOn(true);
             }
@@ -181,9 +181,7 @@ namespace Microsoft.Azure.Management.AppService.Fluent
             }
 
             SkuDescription description = pricingTier.SkuDescription;
-            return !(description.Tier.Equals("Basic", StringComparison.OrdinalIgnoreCase)
-                || description.Tier.Equals("Standard", StringComparison.OrdinalIgnoreCase)
-                || description.Tier.Equals("Premium", StringComparison.OrdinalIgnoreCase));
+            return description.Tier.Equals("Dynamic", StringComparison.OrdinalIgnoreCase);
         }
 
         public override async Task<IFunctionApp> CreateAsync(CancellationToken cancellationToken = default(CancellationToken), bool multiThreaded = true)


### PR DESCRIPTION
The `AutoSetAlwaysOn` and `IsConsumptionAppServicePlan` methods were implemented prior to the PremiumV2 and PremiumV3 app service plan tiers. Consequently, the condition based on string equality can no longer be met for modern premium tiers:

```csharp
public static readonly PricingTier PremiumP1v2 = new PricingTier("PremiumV2", "P1v2");
public static readonly PricingTier PremiumP2v2 = new PricingTier("PremiumV2", "P2v2");
public static readonly PricingTier PremiumP3v2 = new PricingTier("PremiumV2", "P3v2");
public static readonly PricingTier PremiumP1v3 = new PricingTier("PremiumV3", "P1v3");
public static readonly PricingTier PremiumP2v3 = new PricingTier("PremiumV3", "P2v3");
public static readonly PricingTier PremiumP3v3 = new PricingTier("PremiumV3", "P3v3");
```

This causes the *Always On* to be incorrectly set and adds the `WEBSITE_CONTENTAZUREFILECONNECTIONSTRING` and `WEBSITE_CONTENTSHARE` app settings even for non-consumption app service plans.

I also took the liberty of simplifying the `IsConsumptionAppServicePlan` method because the appropriate static field has recently been added to the `PricingTier` class:

```csharp
public static readonly PricingTier ConsumptionY1 = new PricingTier("Dynamic", "Y1");
```