### PR TITLE
support customer provide HttpClient

### DIFF
--- a/src/ResourceManagement/AppService/AppServiceManager.cs
+++ b/src/ResourceManagement/AppService/AppServiceManager.cs
@@ -34,11 +34,9 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         #region ctrs
 
         public AppServiceManager(RestClient restClient, string subscriptionId, string tenantId) :
-            base(restClient, subscriptionId, new WebSiteManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, WebSiteManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
             keyVaultManager = KeyVault.Fluent.KeyVaultManager.Authenticate(restClient, subscriptionId, tenantId);
             storageManager = Storage.Fluent.StorageManager.Authenticate(restClient, subscriptionId);
             graphRbacManager = Graph.RBAC.Fluent.GraphRbacManager.Authenticate(restClient, tenantId);

--- a/src/ResourceManagement/AppService/Generated/WebSiteManagementClient.cs
+++ b/src/ResourceManagement/AppService/Generated/WebSiteManagementClient.cs
@@ -148,6 +148,15 @@ namespace Microsoft.Azure.Management.AppService.Fluent
         {
         }
 
+        private WebSiteManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static WebSiteManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new WebSiteManagementClient(restClient) : new WebSiteManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/BatchAI/BatchAIManager.cs
+++ b/src/ResourceManagement/BatchAI/BatchAIManager.cs
@@ -20,11 +20,9 @@ namespace Microsoft.Azure.Management.BatchAI.Fluent
 
         #region ctrs
         private BatchAIManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new BatchAIManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, BatchAIManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
         #endregion
         #region BatchAIManager builder

--- a/src/ResourceManagement/BatchAI/Generated/BatchAIManagementClient.cs
+++ b/src/ResourceManagement/BatchAI/Generated/BatchAIManagementClient.cs
@@ -108,6 +108,15 @@ namespace Microsoft.Azure.Management.BatchAI.Fluent
         {
         }
 
+        private BatchAIManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static BatchAIManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new BatchAIManagementClient(restClient) : new BatchAIManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Cdn/CdnManager.cs
+++ b/src/ResourceManagement/Cdn/CdnManager.cs
@@ -15,11 +15,9 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         #endregion
 
         public CdnManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new CdnManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, CdnManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
 
         public static ICdnManager Authenticate(AzureCredentials credentials, string subscriptionId)

--- a/src/ResourceManagement/Cdn/Generated/CdnManagementClient.cs
+++ b/src/ResourceManagement/Cdn/Generated/CdnManagementClient.cs
@@ -113,6 +113,15 @@ namespace Microsoft.Azure.Management.Cdn.Fluent
         {
         }
 
+        private CdnManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static CdnManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new CdnManagementClient(restClient) : new CdnManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Compute/ComputeManager.cs
+++ b/src/ResourceManagement/Compute/ComputeManager.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         #region ctrs
 
         public ComputeManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, ComputeManagementClient.newClient(restClient))
+            base(restClient, subscriptionId, ComputeManagementClient.NewInstance(restClient))
         {
             Inner.SubscriptionId = subscriptionId;
             storageManager = StorageManager.Authenticate(restClient, subscriptionId);

--- a/src/ResourceManagement/Compute/ComputeManager.cs
+++ b/src/ResourceManagement/Compute/ComputeManager.cs
@@ -37,11 +37,9 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         #region ctrs
 
         public ComputeManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new ComputeManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, ComputeManagementClient.newClient(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
             storageManager = StorageManager.Authenticate(restClient, subscriptionId);
             networkManager = NetworkManager.Authenticate(restClient, subscriptionId);
             rbacManager = GraphRbacManager.Authenticate(restClient, restClient.Credentials.TenantId);

--- a/src/ResourceManagement/Compute/Generated/ComputeManagementClient.cs
+++ b/src/ResourceManagement/Compute/Generated/ComputeManagementClient.cs
@@ -230,6 +230,15 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         {
         }
 
+        public ComputeManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static ComputeManagementClient newClient(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new ComputeManagementClient(restClient) : new ComputeManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Compute/Generated/ComputeManagementClient.cs
+++ b/src/ResourceManagement/Compute/Generated/ComputeManagementClient.cs
@@ -230,11 +230,11 @@ namespace Microsoft.Azure.Management.Compute.Fluent
         {
         }
 
-        public ComputeManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        private ComputeManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
         {
         }
 
-        public static ComputeManagementClient newClient(RestClient restClient)
+        public static ComputeManagementClient NewInstance(RestClient restClient)
         {
             return restClient.HttpClient == null ? new ComputeManagementClient(restClient) : new ComputeManagementClient(restClient, restClient.HttpClient);
         }

--- a/src/ResourceManagement/ContainerInstance/ContainerInstanceManager.cs
+++ b/src/ResourceManagement/ContainerInstance/ContainerInstanceManager.cs
@@ -23,11 +23,9 @@ namespace Microsoft.Azure.Management.ContainerInstance.Fluent
 
         #region ctrs
         private ContainerInstanceManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new ContainerInstanceManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, ContainerInstanceManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
             this.storageManager = StorageManager.Authenticate(restClient, subscriptionId);
             this.rbacManager = GraphRbacManager.Authenticate(restClient, subscriptionId);
         }

--- a/src/ResourceManagement/ContainerInstance/Generated/ContainerInstanceManagementClient.cs
+++ b/src/ResourceManagement/ContainerInstance/Generated/ContainerInstanceManagementClient.cs
@@ -93,6 +93,15 @@ namespace Microsoft.Azure.Management.ContainerInstance.Fluent
         {
         }
 
+        private ContainerInstanceManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static ContainerInstanceManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new ContainerInstanceManagementClient(restClient) : new ContainerInstanceManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/ContainerRegistry/Generated/ContainerRegistryManagementClient.cs
+++ b/src/ResourceManagement/ContainerRegistry/Generated/ContainerRegistryManagementClient.cs
@@ -99,6 +99,15 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
         {
         }
 
+        private ContainerRegistryManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static ContainerRegistryManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new ContainerRegistryManagementClient(restClient) : new ContainerRegistryManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/ContainerRegistry/RegistryManager.cs
+++ b/src/ResourceManagement/ContainerRegistry/RegistryManager.cs
@@ -18,11 +18,9 @@ namespace Microsoft.Azure.Management.ContainerRegistry.Fluent
         #endregion
 
         public RegistryManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new ContainerRegistryManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, ContainerRegistryManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
             this.storageManager = StorageManager.Authenticate(restClient, subscriptionId);
         }
 

--- a/src/ResourceManagement/ContainerService/ContainerServiceManager.cs
+++ b/src/ResourceManagement/ContainerService/ContainerServiceManager.cs
@@ -16,11 +16,9 @@ namespace Microsoft.Azure.Management.ContainerService.Fluent
         #endregion
 
         public ContainerServiceManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new ContainerServiceManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, ContainerServiceManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
 
         public static IContainerServiceManager Authenticate(AzureCredentials credentials, string subscriptionId)

--- a/src/ResourceManagement/ContainerService/Generated/ContainerServiceManagementClient.cs
+++ b/src/ResourceManagement/ContainerService/Generated/ContainerServiceManagementClient.cs
@@ -115,6 +115,15 @@ namespace Microsoft.Azure.Management.ContainerService.Fluent
         {
         }
 
+        private ContainerServiceManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static ContainerServiceManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new ContainerServiceManagementClient(restClient) : new ContainerServiceManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/CosmosDB/CosmosDBManager.cs
+++ b/src/ResourceManagement/CosmosDB/CosmosDBManager.cs
@@ -15,11 +15,9 @@ namespace Microsoft.Azure.Management.CosmosDB.Fluent
         #endregion
 
         public CosmosDBManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new CosmosDBManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, CosmosDBManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
 
         public static ICosmosDBManager Authenticate(AzureCredentials credentials, string subscriptionId)

--- a/src/ResourceManagement/CosmosDB/Generated/CosmosDBManagementClient.cs
+++ b/src/ResourceManagement/CosmosDB/Generated/CosmosDBManagementClient.cs
@@ -173,6 +173,15 @@ namespace Microsoft.Azure.Management.CosmosDB.Fluent
         {
         }
 
+        private CosmosDBManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static CosmosDBManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new CosmosDBManagementClient(restClient) : new CosmosDBManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Dns/DnsZoneManager.cs
+++ b/src/ResourceManagement/Dns/DnsZoneManager.cs
@@ -18,11 +18,9 @@ namespace Microsoft.Azure.Management.Dns.Fluent
 
 
         public DnsZoneManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new DnsManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, DnsManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
 
         #region DnsZoneManager builder

--- a/src/ResourceManagement/Dns/Generated/DnsManagementClient.cs
+++ b/src/ResourceManagement/Dns/Generated/DnsManagementClient.cs
@@ -96,6 +96,15 @@ namespace Microsoft.Azure.Management.Dns.Fluent
         {
         }
 
+        private DnsManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static DnsManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new DnsManagementClient(restClient) : new DnsManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/EventHub/EventHubManager.cs
+++ b/src/ResourceManagement/EventHub/EventHubManager.cs
@@ -26,11 +26,9 @@ namespace Microsoft.Azure.Management.EventHub.Fluent
 
         #region ctrs
         private EventHubManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new EventHubManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, EventHubManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
             storageManager = StorageManager.Authenticate(restClient, subscriptionId);
         }
 

--- a/src/ResourceManagement/EventHub/Generated/EventHubManagementClient.cs
+++ b/src/ResourceManagement/EventHub/Generated/EventHubManagementClient.cs
@@ -116,6 +116,15 @@ namespace Microsoft.Azure.Management.EventHub.Fluent
         {
         }
 
+        private EventHubManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static EventHubManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new EventHubManagementClient(restClient) : new EventHubManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/Generated/AuthorizationManagementClient.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/AuthorizationManagementClient.cs
@@ -100,6 +100,15 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
         {
         }
 
+        private AuthorizationManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static AuthorizationManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new AuthorizationManagementClient(restClient) : new AuthorizationManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/Generated/GraphRbacManagementClient.cs
+++ b/src/ResourceManagement/Graph.RBAC/Generated/GraphRbacManagementClient.cs
@@ -134,6 +134,15 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
         {
         }
 
+        public GraphRbacManagementClient(string baseUri,  RestClient restClient, System.Net.Http.HttpClient httpClient) : base(baseUri, restClient, httpClient)
+        {
+        }
+
+        public static GraphRbacManagementClient NewInstance(string baseUri, RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new GraphRbacManagementClient(baseUri, restClient) : new GraphRbacManagementClient(baseUri, restClient, restClient.HttpClient);
+        }
+        
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Graph.RBAC/GraphRBACManager.cs
+++ b/src/ResourceManagement/Graph.RBAC/GraphRBACManager.cs
@@ -36,11 +36,9 @@ namespace Microsoft.Azure.Management.Graph.RBAC.Fluent
             {
                 graphEndpoint = restClient.Credentials.Environment.GraphEndpoint;
             }
-            inner = new GraphRbacManagementClient(graphEndpoint, restClient)
-            {
-                TenantID = tenantId
-            };
-            roleInner = new AuthorizationManagementClient(restClient);
+            inner = GraphRbacManagementClient.NewInstance(graphEndpoint, restClient);
+            Inner.TenantID = tenantId;
+            roleInner = AuthorizationManagementClient.NewInstance(restClient);
             this.tenantId = tenantId;
             this.restClient = restClient;
         }

--- a/src/ResourceManagement/KeyVault/Generated/KeyVaultManagementClient.cs
+++ b/src/ResourceManagement/KeyVault/Generated/KeyVaultManagementClient.cs
@@ -86,6 +86,15 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
         {
         }
 
+        private KeyVaultManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static KeyVaultManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new KeyVaultManagementClient(restClient) : new KeyVaultManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/KeyVault/KeyVaultManager.cs
+++ b/src/ResourceManagement/KeyVault/KeyVaultManager.cs
@@ -22,11 +22,9 @@ namespace Microsoft.Azure.Management.KeyVault.Fluent
         #region ctrs
 
         public KeyVaultManager(RestClient restClient, string subscriptionId, string tenantId) :
-            base(restClient, subscriptionId, new KeyVaultManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, KeyVaultManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
             graphRbacManager = GraphRbacManager.Authenticate(restClient, tenantId);
             this.tenantId = tenantId;
         }

--- a/src/ResourceManagement/Locks/AuthorizationManager.cs
+++ b/src/ResourceManagement/Locks/AuthorizationManager.cs
@@ -20,11 +20,9 @@ namespace Microsoft.Azure.Management.Locks.Fluent
 
 
         public AuthorizationManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new ManagementLockClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, ManagementLockClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
 
         #region AuthorizationManager builder

--- a/src/ResourceManagement/Locks/Generated/ManagementLockClient.cs
+++ b/src/ResourceManagement/Locks/Generated/ManagementLockClient.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Azure.Management.Locks.Fluent
         {
         }
 
+        private ManagementLockClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static ManagementLockClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new ManagementLockClient(restClient) : new ManagementLockClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Monitor/Generated/MonitorManagementClient.cs
+++ b/src/ResourceManagement/Monitor/Generated/MonitorManagementClient.cs
@@ -178,6 +178,15 @@ namespace Microsoft.Azure.Management.Monitor.Fluent
         {
         }
 
+        private MonitorManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static MonitorManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new MonitorManagementClient(restClient) : new MonitorManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Monitor/MonitorManager.cs
+++ b/src/ResourceManagement/Monitor/MonitorManager.cs
@@ -19,10 +19,9 @@ namespace Microsoft.Azure.Management.Monitor.Fluent
 
         private static IMonitorManagementClient GetInnerClient(RestClient restClient, string subscriptionId)
         {
-            return new MonitorManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            };
+            IMonitorManagementClient monitorManagementClient = MonitorManagementClient.NewInstance(restClient);
+            monitorManagementClient.SubscriptionId = subscriptionId;
+            return monitorManagementClient;
         }
 
         private MonitorManager(RestClient restClient, string subscriptionId) :

--- a/src/ResourceManagement/Msi/Generated/ManagedServiceIdentityClient.cs
+++ b/src/ResourceManagement/Msi/Generated/ManagedServiceIdentityClient.cs
@@ -84,6 +84,15 @@ namespace Microsoft.Azure.Management.Msi.Fluent
         {
         }
 
+        private ManagedServiceIdentityClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static ManagedServiceIdentityClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new ManagedServiceIdentityClient(restClient) : new ManagedServiceIdentityClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Msi/MsiManager.cs
+++ b/src/ResourceManagement/Msi/MsiManager.cs
@@ -14,11 +14,9 @@ namespace Microsoft.Azure.Management.Msi.Fluent
         private IGraphRbacManager graphRbacManager;
 
         private MsiManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new ManagedServiceIdentityClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, ManagedServiceIdentityClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
             this.graphRbacManager = Microsoft.Azure.Management.Graph.RBAC.Fluent.GraphRbacManager.Authenticate(restClient, restClient.Credentials.TenantId);
         }
 

--- a/src/ResourceManagement/Network/Generated/NetworkManagementClient.cs
+++ b/src/ResourceManagement/Network/Generated/NetworkManagementClient.cs
@@ -519,6 +519,15 @@ namespace Microsoft.Azure.Management.Network.Fluent
         {
         }
 
+        private NetworkManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static NetworkManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new NetworkManagementClient(restClient) : new NetworkManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Network/NetworkManager.cs
+++ b/src/ResourceManagement/Network/NetworkManager.cs
@@ -30,11 +30,9 @@ namespace Microsoft.Azure.Management.Network.Fluent
         private AzureFirewallsImpl azureFirewalls;
 
         private NetworkManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new NetworkManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, NetworkManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
 
         /// <summary>

--- a/src/ResourceManagement/PrivateDns/Generated/PrivateDnsManagementClient.cs
+++ b/src/ResourceManagement/PrivateDns/Generated/PrivateDnsManagementClient.cs
@@ -90,6 +90,15 @@ namespace Microsoft.Azure.Management.PrivateDns.Fluent
         {
         }
 
+        private PrivateDnsManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static PrivateDnsManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new PrivateDnsManagementClient(restClient) : new PrivateDnsManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/PrivateDns/PrivateDnsZoneManager.cs
+++ b/src/ResourceManagement/PrivateDns/PrivateDnsZoneManager.cs
@@ -13,11 +13,9 @@ namespace Microsoft.Azure.Management.PrivateDns.Fluent
         #endregion
 
         public PrivateDnsZoneManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new PrivateDnsManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, PrivateDnsManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
 
         #region PrivateDnsZoneManager builder

--- a/src/ResourceManagement/RedisCache/Generated/RedisManagementClient.cs
+++ b/src/ResourceManagement/RedisCache/Generated/RedisManagementClient.cs
@@ -100,6 +100,15 @@ namespace Microsoft.Azure.Management.Redis.Fluent
         {
         }
 
+        private RedisManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static RedisManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new RedisManagementClient(restClient) : new RedisManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/RedisCache/RedisManager.cs
+++ b/src/ResourceManagement/RedisCache/RedisManager.cs
@@ -15,12 +15,9 @@ namespace Microsoft.Azure.Management.Redis.Fluent
         private IRedisCaches redisCaches;
 
         private RedisManager(RestClient restClient, string subscriptionId)
-            : base(restClient, subscriptionId, new RedisManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            }
-    )
+            : base(restClient, subscriptionId, RedisManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
 
         #region StorageManager builder

--- a/src/ResourceManagement/ResourceManager/Core/AzureConfigurable.cs
+++ b/src/ResourceManagement/ResourceManager/Core/AzureConfigurable.cs
@@ -49,6 +49,12 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
             return this as T;
         }
 
+        public T WithHttpClient(HttpClient httpClient)
+        {
+            restClientBuilder.WithHttpClient(httpClient);
+            return this as T;
+        }
+
         protected RestClient BuildRestClient(AzureCredentials credentials)
         {
             return restClientBuilder

--- a/src/ResourceManagement/ResourceManager/Core/FluentServiceClientBase.cs
+++ b/src/ResourceManagement/ResourceManager/Core/FluentServiceClientBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
         }
 
         protected FluentServiceClientBase(string baseUri, RestClient restClient, HttpClient httpClient)
-            : base(httpClient)
+            : base(httpClient, false)
         {
             Initialize();
             PostInit(baseUri, restClient);

--- a/src/ResourceManagement/ResourceManager/Core/FluentServiceClientBase.cs
+++ b/src/ResourceManagement/ResourceManager/Core/FluentServiceClientBase.cs
@@ -29,10 +29,27 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
         {
         }
 
+        protected FluentServiceClientBase(RestClient restClient, HttpClient httpClient)
+            : this(restClient.BaseUri, restClient, httpClient)
+        {
+        }
+
         protected FluentServiceClientBase(string baseUri, RestClient restClient)
             : base(restClient.RootHttpHandler, restClient.Handlers.ToArray())
         {
             Initialize();
+            PostInit(baseUri, restClient);
+        }
+
+        protected FluentServiceClientBase(string baseUri, RestClient restClient, HttpClient httpClient)
+            : base(httpClient)
+        {
+            Initialize();
+            PostInit(baseUri, restClient);
+        }
+
+        private void PostInit(string baseUri, RestClient restClient)
+        {
             this._restClient = restClient;
             if (baseUri == null)
             {

--- a/src/ResourceManagement/ResourceManager/Core/IAzureConfigurable.cs
+++ b/src/ResourceManagement/ResourceManager/Core/IAzureConfigurable.cs
@@ -15,5 +15,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
         T WithDelegatingHandlers(params DelegatingHandler[] delegatingHandlers);
 
         T WithLogLevel(HttpLoggingDelegatingHandler.Level level);
+
+        T WithHttpClient(HttpClient httpClient);
     }
 }

--- a/src/ResourceManagement/ResourceManager/Core/RestClient/RestClient.cs
+++ b/src/ResourceManagement/ResourceManager/Core/RestClient/RestClient.cs
@@ -61,6 +61,11 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
             get; private set;
         }
 
+        public HttpClient HttpClient
+        {
+            get; private set;
+        }
+
         /// <summary>
         /// Builder to configure and build a RestClient.
         /// </summary>
@@ -79,6 +84,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
             private RetryPolicy retryPolicy;
             private HttpLoggingDelegatingHandler loggingDelegatingHandler;
             private UserAgentDelegatingHandler userAgentDelegatingHandler;
+            private HttpClient httpClient;
 
             /// <summary>
             /// Restrict access so that for users it can be created only by <HttpClient cref="RestClient.Configure" />
@@ -152,6 +158,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
 
                 IBuildable WithCredentials(AzureCredentials credentials);
 
+                IBuildable WithHttpClient(HttpClient httpClient);
+
                 RestClient Build();
             }
             
@@ -213,6 +221,12 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                 return this;
             }
 
+            public IBuildable WithHttpClient(HttpClient httpClient)
+            {
+                this.httpClient = httpClient;
+                return this;
+            }
+
             public RestClient Build()
             {
                 HttpClientHandler httpClientHandler = new HttpClientHandler();
@@ -222,7 +236,8 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent.Core
                     BaseUri = baseUri,
                     Credentials = credentials,
                     RetryPolicy = retryPolicy,
-                    Environment = this.Environment
+                    Environment = this.Environment,
+                    HttpClient = this.httpClient
                 };
             }
 

--- a/src/ResourceManagement/ResourceManager/Generated/FeatureClient.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/FeatureClient.cs
@@ -85,6 +85,15 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         {
         }
 
+        private FeatureClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static FeatureClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new FeatureClient(restClient) : new FeatureClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/ResourceManager/Generated/PolicyClient.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/PolicyClient.cs
@@ -87,6 +87,15 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         {
         }
 
+        private PolicyClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static PolicyClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new PolicyClient(restClient) : new PolicyClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/ResourceManager/Generated/ResourceManagementClient.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/ResourceManagementClient.cs
@@ -106,6 +106,15 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         {
         }
 
+        private ResourceManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static ResourceManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new ResourceManagementClient(restClient) : new ResourceManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/ResourceManager/Generated/SubscriptionClient.cs
+++ b/src/ResourceManagement/ResourceManager/Generated/SubscriptionClient.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         {
         }
 
+        private SubscriptionClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static SubscriptionClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new SubscriptionClient(restClient) : new SubscriptionClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/ResourceManager/ResourceManager.cs
+++ b/src/ResourceManagement/ResourceManager/ResourceManager.cs
@@ -19,19 +19,13 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         #region ctrs
 
         private ResourceManager(RestClient restClient, string subscriptionId) :
-            base(null, subscriptionId, new ResourceManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(null, subscriptionId, ResourceManagementClient.NewInstance(restClient))
         {
-            featureClient = new FeatureClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            };
-            policyClient = new PolicyClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            };
+            Inner.SubscriptionId = subscriptionId;
+            featureClient = FeatureClient.NewInstance(restClient);
+            featureClient.SubscriptionId = subscriptionId;
+            policyClient = PolicyClient.NewInstance(restClient);
+            policyClient.SubscriptionId = subscriptionId;
             ResourceManager = this;
         }
 
@@ -42,11 +36,10 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
         public static IAuthenticated Authenticate(AzureCredentials credentials)
         {
             return new Authenticated(RestClient.Configure()
-                    .WithEnvironment(credentials.Environment)
-                    .WithCredentials(credentials)
-                    .WithDelegatingHandler(new ProviderRegistrationDelegatingHandler(credentials))
-                    .Build()
-                );
+                .WithEnvironment(credentials.Environment)
+                .WithCredentials(credentials)
+                .WithDelegatingHandler(new ProviderRegistrationDelegatingHandler(credentials))
+                .Build());
         }
 
         public static IAuthenticated Authenticate(RestClient restClient)
@@ -94,7 +87,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
             public Authenticated(RestClient restClient)
             {
                 this.restClient = restClient;
-                subscriptionClient = new SubscriptionClient(restClient);
+                subscriptionClient = SubscriptionClient.NewInstance(restClient);
             }
 
             #region Implementaiton of IAuthenticated interface

--- a/src/ResourceManagement/Search/Generated/SearchManagementClient.cs
+++ b/src/ResourceManagement/Search/Generated/SearchManagementClient.cs
@@ -92,6 +92,15 @@ namespace Microsoft.Azure.Management.Search.Fluent
         {
         }
 
+        private SearchManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static SearchManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new SearchManagementClient(restClient) : new SearchManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Search/SearchManager.cs
+++ b/src/ResourceManagement/Search/SearchManager.cs
@@ -15,11 +15,9 @@ namespace Microsoft.Azure.Management.Search.Fluent
         #endregion
 
         public SearchManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new SearchManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, SearchManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
 
         public static ISearchManager Authenticate(AzureCredentials credentials, string subscriptionId)

--- a/src/ResourceManagement/ServiceBus/Generated/ServiceBusManagementClient.cs
+++ b/src/ResourceManagement/ServiceBus/Generated/ServiceBusManagementClient.cs
@@ -102,6 +102,15 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
         {
         }
 
+        private ServiceBusManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static ServiceBusManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new ServiceBusManagementClient(restClient) : new ComputeMServiceBusManagementClientanagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/ServiceBus/Generated/ServiceBusManagementClient.cs
+++ b/src/ResourceManagement/ServiceBus/Generated/ServiceBusManagementClient.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
 
         public static ServiceBusManagementClient NewInstance(RestClient restClient)
         {
-            return restClient.HttpClient == null ? new ServiceBusManagementClient(restClient) : new ComputeMServiceBusManagementClientanagementClient(restClient, restClient.HttpClient);
+            return restClient.HttpClient == null ? new ServiceBusManagementClient(restClient) : new ServiceBusManagementClient(restClient, restClient.HttpClient);
         }
 
         /// <summary>

--- a/src/ResourceManagement/ServiceBus/ServiceBusManager.cs
+++ b/src/ResourceManagement/ServiceBus/ServiceBusManager.cs
@@ -20,11 +20,9 @@ namespace Microsoft.Azure.Management.ServiceBus.Fluent
 
 
         public ServiceBusManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new ServiceBusManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, ServiceBusManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
 
         #region ServiceBusManager builder

--- a/src/ResourceManagement/Sql/Generated/SqlManagementClient.cs
+++ b/src/ResourceManagement/Sql/Generated/SqlManagementClient.cs
@@ -684,6 +684,15 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         {
         }
 
+        private SqlManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static SqlManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new SqlManagementClient(restClient) : new SqlManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Sql/SqlManager.cs
+++ b/src/ResourceManagement/Sql/SqlManager.cs
@@ -14,11 +14,9 @@ namespace Microsoft.Azure.Management.Sql.Fluent
         private string tenantId;
 
         public SqlManager(RestClient restClient, string subscriptionId, string tenantId) :
-            base(restClient, subscriptionId, new SqlManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, SqlManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
             this.tenantId = tenantId;
         }
 

--- a/src/ResourceManagement/Storage/Generated/StorageManagementClient.cs
+++ b/src/ResourceManagement/Storage/Generated/StorageManagementClient.cs
@@ -108,6 +108,15 @@ namespace Microsoft.Azure.Management.Storage.Fluent
         {
         }
 
+        private StorageManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static StorageManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new StorageManagementClient(restClient) : new StorageManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/Storage/StorageManager.cs
+++ b/src/ResourceManagement/Storage/StorageManager.cs
@@ -13,11 +13,9 @@ namespace Microsoft.Azure.Management.Storage.Fluent
         #region ctrs
 
         private StorageManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new StorageManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, StorageManagementClient.NewInstance(restClient))
         {
+            Inner.SubscriptionId = subscriptionId;
         }
 
         #endregion

--- a/src/ResourceManagement/TrafficManager/Generated/TrafficManagerManagementClient.cs
+++ b/src/ResourceManagement/TrafficManager/Generated/TrafficManagerManagementClient.cs
@@ -102,6 +102,15 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
         {
         }
 
+        private TrafficManagerManagementClient(RestClient restClient, System.Net.Http.HttpClient httpClient) : base(restClient, httpClient)
+        {
+        }
+
+        public static TrafficManagerManagementClient NewInstance(RestClient restClient)
+        {
+            return restClient.HttpClient == null ? new TrafficManagerManagementClient(restClient) : new TrafficManagerManagementClient(restClient, restClient.HttpClient);
+        }
+
         /// <summary>
         /// An optional partial-method to perform custom initialization.
         /// </summary>

--- a/src/ResourceManagement/TrafficManager/TrafficManager.cs
+++ b/src/ResourceManagement/TrafficManager/TrafficManager.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
         public TrafficManager(RestClient restClient, string subscriptionId) :
             base(restClient, subscriptionId, TrafficManagerManagementClient.NewInstance(restClient))
         {
-            nner.SubscriptionId = subscriptionId;
+            Inner.SubscriptionId = subscriptionId;
         }
 
         #region DnsZoneManager builder

--- a/src/ResourceManagement/TrafficManager/TrafficManager.cs
+++ b/src/ResourceManagement/TrafficManager/TrafficManager.cs
@@ -15,11 +15,9 @@ namespace Microsoft.Azure.Management.TrafficManager.Fluent
         #endregion
 
         public TrafficManager(RestClient restClient, string subscriptionId) :
-            base(restClient, subscriptionId, new TrafficManagerManagementClient(restClient)
-            {
-                SubscriptionId = subscriptionId
-            })
+            base(restClient, subscriptionId, TrafficManagerManagementClient.NewInstance(restClient))
         {
+            nner.SubscriptionId = subscriptionId;
         }
 
         #region DnsZoneManager builder


### PR DESCRIPTION
For 2 usages:
1. Not want to use the default handler pipeline in ClientRuntime https://github.com/Azure/azure-sdk-for-net/blob/a0a6f5e9542927d4f5da57b5e152082643c3ba73/sdk/mgmtcommon/ClientRuntime/ClientRuntime/ServiceClient.cs#L376-L401
2. Would like to use a single `HttpClient` for all azure clients (e.g. in Azure Function App)

One can use it as such:
```
            HttpMessageHandler handler = new RetryDelegatingHandler(new HttpLoggingDelegatingHandler(new HttpClientHandler()) { LogLevel = HttpLoggingDelegatingHandler.Level.BodyAndHeaders });
            HttpClient httpClient = new HttpClient(handler, true);

            var azure = Azure.Configure()
                .WithHttpClient(httpClient)
                .Authenticate(credentials)
                .WithSubscription(subscriptionId);
```

Note that all other configuration on the handler pipeline will be ignored in this case (WithUserAgent, WithRetryPolicy, WithDelegatingHandler, WithDelegatingHandlers, WithLogLevel), as well as other [default handler in ClientRuntime](https://github.com/Azure/azure-sdk-for-net/blob/a0a6f5e9542927d4f5da57b5e152082643c3ba73/sdk/mgmtcommon/ClientRuntime/ClientRuntime/ServiceClient.cs#L376-L401).