### PR TITLE
Fixed missing universal conversion in samples.

### DIFF
--- a/Samples/Monitor/QueryMetricsAndActivityLogs.cs
+++ b/Samples/Monitor/QueryMetricsAndActivityLogs.cs
@@ -55,7 +55,7 @@ namespace QueryMetricsAndActivityLogs
                 // Add some blob transaction events
                 AddBlobTransactions(storageConnectionString);
 
-                DateTime recordDateTime = DateTime.Now;
+                DateTime recordDateTime = DateTime.Now.ToUniversalTime();
                 // get metric definitions for storage account.
                 foreach (var metricDefinition in azure.MetricDefinitions.ListByResource(storageAccount.Id))
                 {

--- a/Samples/Monitor/SecurityBreachOrRiskActivityLogAlerts.cs
+++ b/Samples/Monitor/SecurityBreachOrRiskActivityLogAlerts.cs
@@ -82,7 +82,7 @@ namespace SecurityBreachOrRiskActivityLogAlerts
                 // for near real time monitoring.
                 SdkContext.DelayProvider.Delay(6 * 60000);
 
-                DateTime recordDateTime = DateTime.Now;
+                DateTime recordDateTime = DateTime.Now.ToUniversalTime();
                 // get activity logs for the same period.
                 var logs = azure.ActivityLogs.DefineQuery()
                         .StartingFrom(recordDateTime.AddDays(-7))


### PR DESCRIPTION
Some of the samples for querying metrics will not work currently because date-conversion to universal time is missing. I fixed it by simply adding the conversion in those samples.

Fixes the reason #1232 originally was created by me.