### PR TITLE
Fix null hostnames in ApplicationGatewayHttpListener

### DIFF
--- a/src/ResourceManagement/Network/Generated/Models/ApplicationGatewayHttpListenerInner.cs
+++ b/src/ResourceManagement/Network/Generated/Models/ApplicationGatewayHttpListenerInner.cs
@@ -54,14 +54,14 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
         /// of the HTTP listener.</param>
         /// <param name="firewallPolicy">Reference to the FirewallPolicy
         /// resource.</param>
-        /// <param name="hostnames">List of Host names for HTTP Listener that
+        /// <param name="hostNames">List of Host names for HTTP Listener that
         /// allows special wildcard characters as well.</param>
         /// <param name="name">Name of the HTTP listener that is unique within
         /// an Application Gateway.</param>
         /// <param name="etag">A unique read-only string that changes whenever
         /// the resource is updated.</param>
         /// <param name="type">Type of the resource.</param>
-        public ApplicationGatewayHttpListenerInner(string id = default(string), Management.ResourceManager.Fluent.SubResource frontendIPConfiguration = default(Management.ResourceManager.Fluent.SubResource), Management.ResourceManager.Fluent.SubResource frontendPort = default(Management.ResourceManager.Fluent.SubResource), ApplicationGatewayProtocol protocol = default(ApplicationGatewayProtocol), string hostName = default(string), Management.ResourceManager.Fluent.SubResource sslCertificate = default(Management.ResourceManager.Fluent.SubResource), bool? requireServerNameIndication = default(bool?), ProvisioningState provisioningState = default(ProvisioningState), IList<ApplicationGatewayCustomError> customErrorConfigurations = default(IList<ApplicationGatewayCustomError>), Management.ResourceManager.Fluent.SubResource firewallPolicy = default(Management.ResourceManager.Fluent.SubResource), IList<string> hostnames = default(IList<string>), string name = default(string), string etag = default(string), string type = default(string))
+        public ApplicationGatewayHttpListenerInner(string id = default(string), Management.ResourceManager.Fluent.SubResource frontendIPConfiguration = default(Management.ResourceManager.Fluent.SubResource), Management.ResourceManager.Fluent.SubResource frontendPort = default(Management.ResourceManager.Fluent.SubResource), ApplicationGatewayProtocol protocol = default(ApplicationGatewayProtocol), string hostName = default(string), Management.ResourceManager.Fluent.SubResource sslCertificate = default(Management.ResourceManager.Fluent.SubResource), bool? requireServerNameIndication = default(bool?), ProvisioningState provisioningState = default(ProvisioningState), IList<ApplicationGatewayCustomError> customErrorConfigurations = default(IList<ApplicationGatewayCustomError>), Management.ResourceManager.Fluent.SubResource firewallPolicy = default(Management.ResourceManager.Fluent.SubResource), IList<string> hostNames = default(IList<string>), string name = default(string), string etag = default(string), string type = default(string))
             : base(id)
         {
             FrontendIPConfiguration = frontendIPConfiguration;
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
             ProvisioningState = provisioningState;
             CustomErrorConfigurations = customErrorConfigurations;
             FirewallPolicy = firewallPolicy;
-            Hostnames = hostnames;
+            HostNames = hostNames;
             Name = name;
             Etag = etag;
             Type = type;
@@ -147,8 +147,8 @@ namespace Microsoft.Azure.Management.Network.Fluent.Models
         /// Gets or sets list of Host names for HTTP Listener that allows
         /// special wildcard characters as well.
         /// </summary>
-        [JsonProperty(PropertyName = "properties.hostnames")]
-        public IList<string> Hostnames { get; set; }
+        [JsonProperty(PropertyName = "properties.hostNames")]
+        public IList<string> HostNames { get; set; }
 
         /// <summary>
         /// Gets or sets name of the HTTP listener that is unique within an


### PR DESCRIPTION
This fixes a bug with the ApplicationGatewayHttpListenerInner resulting in null hostnames when utilizing the multiple hostnames and/or wildcard hostnames feature in an HTTP Listener. 

Null hostnames results in the following error when applying any changes to an Application Gateway using this feature:
HostName must be specified if RequireServerNameIndication is true in Http Listener

StackTrace: ```Microsoft.Azure.WebJobs.Host.FunctionInvocationException: Exception while executing function: SetActiveDeploymentSlot
---> System.AggregateException: One or more errors occurred. (HostName must be specified if RequireServerNameIndication is true in Http Listener /subscriptions/REDACTED/resourceGroups/REDACTED/providers/Microsoft.Network/applicationGateways/REDACTED/httpListeners/REDACTED.)
---> Microsoft.Rest.Azure.CloudException: HostName must be specified if RequireServerNameIndication is true in Http Listener /subscriptions/REDACTED/resourceGroups/REDACTED/providers/Microsoft.Network/applicationGateways/REDACTED/httpListeners/REDACTED.
  at Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaysOperations.BeginCreateOrUpdateWithHttpMessagesAsync(String resourceGroupName, String applicationGatewayName, ApplicationGatewayInner parameters, Dictionary`2 customHeaders, CancellationToken cancellationToken)
  at Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaysOperations.CreateOrUpdateWithHttpMessagesAsync(String resourceGroupName, String applicationGatewayName, ApplicationGatewayInner parameters, Dictionary`2 customHeaders, CancellationToken cancellationToken)
  at Microsoft.Azure.Management.Network.Fluent.ApplicationGatewaysOperationsExtensions.CreateOrUpdateAsync(IApplicationGatewaysOperations operations, String resourceGroupName, String applicationGatewayName, ApplicationGatewayInner parameters, CancellationToken cancellationToken)
  at Microsoft.Azure.Management.Network.Fluent.ApplicationGatewayImpl.CreateInnerAsync(CancellationToken cancellationToken)
  at Microsoft.Azure.Management.ResourceManager.Fluent.Core.GroupableParentResource`8.CreateResourceAsync(CancellationToken cancellationToken)
  at Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.Creatable`4.Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.IResourceCreator<IResourceT>.CreateResourceAsync(CancellationToken cancellationToken)
  at Microsoft.Azure.Management.ResourceManager.Fluent.Core.DAG.CreatorTaskItem`1.ExecuteAsync(CancellationToken cancellationToken)
  at Microsoft.Azure.Management.ResourceManager.Fluent.Core.DAG.TaskGroupBase`1.ExecuteNodeTaskAsync(DAGNode`1 node, CancellationToken cancellationToken)
  at Microsoft.Azure.Management.ResourceManager.Fluent.Core.ResourceActions.CreatableUpdatable`5.ApplyAsync(CancellationToken cancellationToken, Boolean multiThreaded)
 --- End of inner exception stack trace ---```