### PR TITLE
Update AzureEnvironment.cs remove Endpoint that will be deprecated

### DIFF
--- a/src/ResourceManagement/ResourceManager/AzureEnvironment.cs
+++ b/src/ResourceManagement/ResourceManager/AzureEnvironment.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Management.ResourceManager.Fluent
                 AuthenticationEndpoint = "https://login.microsoftonline.com/",
                 ResourceManagerEndpoint = "https://management.azure.com/",
                 ManagementEndpoint = "https://management.core.windows.net/",
-                GraphEndpoint = "https://graph.windows.net/",
+                GraphEndpoint = "https://graph.microsoft.com/",
                 StorageEndpointSuffix = "core.windows.net",
                 KeyVaultSuffix = "vault.azure.net"
             };


### PR DESCRIPTION
Graph Windows.Net endpoint will be deprecated September 30th, affecting all services calling this library with failures