### PR TITLE
Update SSH.NET to 2023.0.0

### DIFF
--- a/Samples/Samples.csproj
+++ b/Samples/Samples.csproj
@@ -32,7 +32,7 @@
     <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.24" />
     <PackageReference Include="CoreFTP" Version="1.2.0" />
     <PackageReference Include="Microsoft.Azure.ServiceBus" Version="0.0.2-preview" />
-    <PackageReference Include="SSH.NET" Version="2016.0.0" />
+    <PackageReference Include="SSH.NET" Version="2023.0.0" />
     <PackageReference Include="Docker.DotNet" Version="2.124.3" />
     <PackageReference Include="Docker.DotNet.X509" Version="2.124.3" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.3" />

--- a/Tests/AzSdk.test.reference.props
+++ b/Tests/AzSdk.test.reference.props
@@ -4,7 +4,7 @@
     <PackageReference Include="Microsoft.Azure.Test.HttpRecorder" Version="1.13.3" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="1.7.7" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
-    <PackageReference Include="SSH.NET" Version="2016.0.0" />
+    <PackageReference Include="SSH.NET" Version="2023.0.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     


### PR DESCRIPTION
Update SSH.NET to the latest version https://www.nuget.org/packages/SSH.NET/2023.0.0

## New features:
* Support for .NET 6, 7, and .NET Standard 2.0/2.1
* Support for RSA-SHA256/512 signature algorithms
* Support for parsing OpenSSH keys with ECDSA 256/384/521 and RSA
* Support for SHA256 and MD5 fingerprints for host key validation
* Added async support to SftpClient and SftpFileStream
* Added ISftpFile interface to SftpFile
* Removed support for old target frameworks
* Improved performance and stability
* Added the ability to set the last write and access time for Sftp files